### PR TITLE
Moved component list earlier in the MIP template.

### DIFF
--- a/mip0.md
+++ b/mip0.md
@@ -12,6 +12,19 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
+### Components
+**MIP0c1:** Definitions of the Maker Improvement Proposal Framework  
+**MIP0c2:** Three Core Principles  
+**MIP0c3:** The MIP Lifecycle  
+**MIP0c4:** MIP Components and MIP Component Types  
+**MIP0c5:** MIP Replacement Process  
+**MIP0c6:** MIP Templates  
+**MIP0c7:** MIP0 Domain Role Dependencies  
+**MIP0c8:** MIP Editor Election Process  
+**MIP0c9:** MIP Editor Removal Process  
+**MIP0c10:** Governance Facilitator Election Process  
+**MIP0c11:** Governance Facilitator Removal Process  
+
 ## Summary
 
 MIP0 is the genesis proposal describing the MIPs Framework. This includes the core components and statuses as well as the various MIP types and the overall MIP lifecycle. Furthermore, it provides the necessary tools, such as MIP templates, replacement processes, and dependencies. Lastly, the proposal details the key roles of the framework, the MIP Editor and the Governance Facilitator along with the process for adding and removing them.
@@ -30,22 +43,6 @@ In order for MIPs to be functional they need to comply with a basic standard out
 
 
 ## Specification / Proposal Details
-
-
-### MIP0 Components
-1. **MIP0c1:** Definitions of the Maker Improvement Proposal Framework
-2. **MIP0c2:** Three Core Principles
-3. **MIP0c3:** The MIP Lifecycle
-4. **MIP0c4:** MIP Components and MIP Component Types
-6. **MIP0c5:** MIP Replacement Process
-7. **MIP0c6:** MIP Templates
-8. **MIP0c7:** MIP0 Domain Role Dependencies
-9. **MIP0c8:** MIP Editor Election Process  
-10. **MIP0c9:** MIP Editor Removal Process
-11. **MIP0c10:** Governance Facilitator Election Process
-12. **MIP0c11:** Governance Facilitator Removal Process
-
----
 
 ### MIP0c1: Definitions of the Maker Improvement Proposal Framework
 
@@ -224,7 +221,10 @@ Date Proposed: <date created on, in (yyyy-mm-dd) format>
 Dependencies: n/a
 Replaces: n/a
 ```
-  
+**Components**
+
+A list of components that are included in the specification / proposal details.
+
 **Summary**
 
 A description of what the Maker Improvement Proposal (MIP) is focused on.
@@ -253,6 +253,9 @@ Dependencies: <List of depdendent MIPs>
 Replaces: <List of MIP it is replacing>
 License: <added by MIP Author>
 ```
+**Components**
+
+A list of components that are included in the specification.
 
 **Summary**
 

--- a/mip1.md
+++ b/mip1.md
@@ -12,6 +12,11 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
+### Components
+**MIP1c1:** Definitions  
+**MIP1c2:** The Initial Problem Space  
+**MIP1c3:** Changing the Problem Space  
+
 ## Summary
 
 A Governance Paradigm is a complete and specific group of MIP Sets that solve an entire problem space. A problem space is defined as a list of issues that must be addressed in order for the Maker Protocol to be able to sustain itself and grow into the future Maker governance.
@@ -23,14 +28,6 @@ The goal of having a defined governance paradigm is to give the community a comp
 It is important at all times to have the best possible estimate of what the long-term problem space list will look like. The current list defined within this MIP represents the problems that the Maker Foundation currently believes need to be addressed in order to enable MakerDAO to become self-sustainable. The expectation is that this list will be changed over time as practical experience of the community is gained. After the ratification of this MIP, the Maker community can use the subproposal process to change the list at any time. Therefore, the problem space list is not permanent. The problem space list serves as a best estimate for the problems the Maker community must solve for over the course of the next few years and is expected to change as more information become available. 
 
 ## Specification / Proposal Details
-
-### MIP1 Components
-
-1. **MIP1c1:** Definitions
-2. **MIP1c2:** The Initial Problem Space
-3. **MIP1c3:** Changing the Problem Space
-
----
 
 ### MIP1c1: Definitions
 

--- a/mip10.md
+++ b/mip10.md
@@ -13,6 +13,12 @@
     Replaces: n/a
     
 
+### Components
+**MIP10c1:** Oracle Onboarding  
+**MIP10c2:** List of Active Oracle Data Models  
+**MIP10c3:** Process for onboarding  
+**MIP10c4:** Process for offboarding  
+
 ## Summary
 
 This proposal defines the process for onboarding, offboarding and managing oracles.
@@ -22,15 +28,6 @@ This proposal defines the process for onboarding, offboarding and managing oracl
 In the Maker Protocol, every collateral type has a corresponding Oracle that publishes a reference price that the protocol utilizes. Therefore, the Oracle requirements must be laid out in detail for the collateral onboarding process. Governance may also choose to create Oracles for non-collateral assets for use by 3rd parties.
 
 ## Specification / Proposal Details
-
-### MIP10 Components
-
-1. **MIP10c1:** Oracle Onboarding
-2. **MIP10c2:** List of Active Oracle Data Models
-3. **MIP10c3:** Process for onboarding
-4. **MIP10c4:** Process for offboarding
-
----
 
 ### MIP10c1: Oracle Onboarding
 

--- a/mip11.md
+++ b/mip11.md
@@ -11,6 +11,11 @@ Date Proposed: 2020-04-06
 Dependencies: MIP0, MIP3, MIP7
 Replaces: n/a
 ```
+### Components
+**MIP11c1:** General Risk Model Requirements  
+**MIP11c2:** List of Active General Risk Models  
+**MIP11c3:** Process for Onboarding  
+**MIP11c4:** Process for offboarding  
 
 ## Summary
 
@@ -21,15 +26,6 @@ This proposal defines the process and requirements for risk teams to onboard gen
 Risk models are a crucial element of the Maker Protocol's maintenance and growth. The models provide a representation of how a risk team intends to evaluate an asset or other part of the risk function. Therefore, the purpose of this proposal is to create a defined and formalized process for Risk teams to more easily onboard their models to the Maker Protocol and ultimately help grow and maintain the Protocol.
 
 ## Specification / Proposal Details
-
-### MIP11 Components
-
-1. **MIP11c1:** General Risk Model Requirements
-2. **MIP11c2:** List of Active General Risk Models
-3. **MIP11c3:** Process for Onboarding
-4. **MIP11c4:** Process for offboarding
-
----
 
 ### MIP11c1: General Risk Model Requirements
 

--- a/mip12.md
+++ b/mip12.md
@@ -12,6 +12,11 @@ Dependencies: MIP0, MIP3, MIP7, MIP10, MIP11
 Replaces: n/a
 ```  
 
+### MIP11 Components
+**MIP12c1:** Domain Team Requirements for Onboarding Collateral Type to the Maker Protocol  
+**MIP12c2:** Proposing New Risk Parameters, Oracles, and Collateral Adapters  
+**MIP12c3:** Collateral Type Checklist (Governance)  
+
 ## Summary
 
 This proposal defines the documentation requirements for the onboarding of a new collateral type to the Maker Protocol, more specifically, the risk teams' objectives and requirements to deliver it in a unified package risk construct.
@@ -21,14 +26,6 @@ This proposal defines the documentation requirements for the onboarding of a new
 This proposal will focus on the collateral onboarding process blueprint for submitting MIP12 Subproposals (MIP12-SPs). The subproposals allow any community member to propose new risk parameters, oracles, and adapters for a new, or existing collateral type. Additionally, it will also define priority polls and the overall collateral onboarding process requirements. Furthermore, it allows domain teams to execute on collateral onboarding via the executive vote. This is the last step that needs to be completed when you have the risk construct with risk parameters based on a risk model ratified through MIP11.
 
 ## Specification / Proposal Details
-
-### MIP11 Components
-
-1. **MIP12c1:** Domain Team Requirements for Onboarding Collateral Type to the Maker Protocol
-2. **MIP12c2:** Proposing New Risk Parameters, Oracles, and Collateral Adapters
-3. **MIP12c3:** Collateral Type Checklist (Governance)
-
----
 
 ### MIP12c1: Domain Team Requirements for Onboarding Collateral Type to the Maker Protocol
 

--- a/mip2.md
+++ b/mip2.md
@@ -13,6 +13,11 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
+### Components
+**MIP2c1:** Interim Phase 1  
+**MIP2c2:** Interim Phase 2  
+**MIP2c3:** MIP2 Obsolescence  
+
 ## Summary
 
 This proposal details the process of how Maker Governance can bootstrap the setup and implementation of the first Governance Paradigm. More specifically, it defines two phases: 
@@ -33,14 +38,6 @@ However, these two goals contradict each other in the initial "launch period" wh
 As a result, the community should prioritize getting the initial processes in place that will cover all the critical risks and opportunities that are built as a formalization of existing processes or knowledge in the community and Maker Foundation. Once the initial governance paradigm is in place the community can amend or replace it as necessary to build a more permanent and robust paradigm, taking advantage of the practical knowledge gained in the interim period.
 
 ## Specification / Proposal Details
-
-### MIP2 Components
-
-1. **MIP2c1:** Interim Phase 1
-2. **MIP2c2:** Interim Phase 2
-3. **MIP2c3:** MIP2 Obsolescence 
-
----
 
 ### MIP2c1: Interim Phase 1
 

--- a/mip3.md
+++ b/mip3.md
@@ -12,6 +12,10 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
+### Components
+**MIP3c1:** Governance Cycle Breakdown  
+**MIP3c2:** Default Inclusion Threshold Modification Subproposals  
+
 ## Summary
 
 This proposal formally introduces a Governance Cycle. The Governance Cycle provides a predictable framework for Maker Governance decisions. Furthermore, it provides participants (MKR holders) with a monthly overview of the decisions that are to be made, allowing participation despite time constraints.
@@ -23,12 +27,6 @@ The goal of the standardized monthly governance cycle is to provide advance noti
 The structure of the governance cycle enables active governance participants to join the discussion at the proposal submission level from the beginning of the month, while less active governance participants can simply review the end results at the end of the month and decide whether or not to vote for the final executive vote.
 
 ## Specification / Proposal Details
-
-### MIP3 Components
-
-1. **MIP3c1:** Governance Cycle Breakdown
-2. **MIP3c2:** Default Inclusion Threshold Modification Subproposals
----
 
 ### MIP3c1: Governance Cycle Breakdown
 

--- a/mip4.md
+++ b/mip4.md
@@ -12,6 +12,11 @@ Dependencies: n/a
 Replaces: n/a
   ```
 
+### Components
+**MIP4c1:** Purpose Description  
+**MIP4c2:** MIP Amendment Process  
+**MIP4c3:** MIP Removal Process  
+
 ## Summary
 
 The Amendment and Removal Process-MIP outlines the process for very small and relatively superficial changes to MIPs. This MIP Contains two Process Components, the first dealing with the Removal of ratified MIPs, and the second dealing with Amending current active MIPs.
@@ -22,14 +27,6 @@ The motivation behind this proposal is that changing small details to MIPs shoul
   
 
 ## Specification / Proposal Details
-
-### MIP4 Components
-
-1. **MIP4c1:** Purpose Description
-2. **MIP4c2:** MIP Amendment Process 
-3. **MIP4c3:** MIP Removal Process 
-
----
 
 ### MIP4c1: Purpose Description
 

--- a/mip5.md
+++ b/mip5.md
@@ -11,6 +11,9 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
+### Components
+**MIP5c1:** Governance Facilitator Emergency Votes  
+**MIP5c2:** An Emergency State Change  
 
 ## Summary
 
@@ -22,13 +25,6 @@ This standard is being proposed in order to allow the community to overcome the 
 
 
 ## Specification / Proposal Details
-
-### MIP5 Components
-
-1. **MIP5c1:** Governance Facilitator Emergency Votes
-2. **MIP5c2:** An Emergency State Change
-
----
 
 ### MIP5c1: Governance Facilitator Emergency Votes
 

--- a/mip6.md
+++ b/mip6.md
@@ -12,6 +12,11 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
+### Components
+**MIP6c1:** Process Overview  
+**MIP6c2:** Application Form Template  
+**MIP6c3:** Sub Proposal Framework  
+
 ## Summary
 
 The purpose of this proposal is to standardize the collateral onboarding form/forum template that community members and third-party projects can use to begin the process of getting their collateral onboarded to the Maker Protocol.
@@ -23,14 +28,6 @@ This proposal aims to layout one part of the generalized process for adding coll
 Although this is only one component of the overall collateral onboarding process, this proposed standard would decrease confusion surrounding how to start the process of getting collateral added to the Maker Protocol and ultimately, increase the onboarding speed at which new collateral types can be onboarded.
 
 ## Specification / Proposal Details
-
-### MIP6 Components
-
-1. **MIP6c1:** Process Overview
-2. **MIP6c2:** Application Form Template
-3. **MIP6c3:** Sub Proposal Framework
-
----
 
 ### MIP6c1: Process Overview
 

--- a/mip7.md
+++ b/mip7.md
@@ -12,6 +12,12 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
+### Components
+**MIP7c1:** Domain Team Descriptions  
+**MIP7c2:** The Current Domain Roles List  
+**MIP7c3:** Domain Team onboarding  
+**MIP7c4:** Domain Team offboarding  
+
 ## Summary
 
 The Domain Teams Onboarding & Offboarding proposal provides a predictable framework for both onboarding and offboarding domain teams required for the collateral onboarding process.
@@ -22,14 +28,6 @@ The Maker Protocol requires a decentralized workforce in order to onboard new co
 
 ## Specification / Proposal Details
 
-### MIP7 Components
-
-1. **MIP7c1:** Domain Team Descriptions
-2. **MIP7c2:** The Current Domain Roles List
-3. **MIP7c3:** Domain Team onboarding
-4. **MIP7c4:** Domain Team offboarding
-
----
 ### MIP7c1: Domain Team Descriptions
 
 

--- a/mip8.md
+++ b/mip8.md
@@ -11,6 +11,8 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
+### Components
+**MIP8c1:** The Domain Greenlight Requirements and Process  
 
 ## Summary
 
@@ -23,13 +25,6 @@ The goal of this proposal is to inform the community about the pre-evaluation st
 ## Specification / Proposal Details
 
 In this stage, the domain teams will signal that they believe the collateral type is worth the time to perform a full evaluation in their respective domain. Note that this stage may happen in parallel to the MIP6 process, but communication from the Domain teams should always come within two weeks of the end of the allotted review time for MIP6's collateral onboarding form/forum publication. 
-
-
-### MIP8 Components
-
-1. **MIP8c1:** The Domain Greenlight Requirements and Process
-
----
 
 ### MIP8c1: The Domain Greenlight Requirements and Process
 

--- a/mip9.md
+++ b/mip9.md
@@ -13,6 +13,9 @@ Dependencies: MIP6, MIP8
 Replaces: n/a
 ```
 
+### Components
+**MIP9c1:** The Community Greenlight Requirements and Process  
+**MIP9c2:** Governance Poll Template  
 
 ## Summary
 
@@ -26,13 +29,6 @@ While domain teams are free to choose their own workload, an on-chain governance
 ## Specification / Proposal Details
 
 In this stage, the Governance Facilitator (GF) will create an on-chain governance poll in the template format defined in MIP9c2 and the community will vote with their preferences.
-
-### MIP9 Components
-
-1. **MIP9c1:** The Community Greenlight Requirements and Process
-2. **MIP9c2:** Governance Poll Template 
-
----
 
 ### MIP9c1: The Community Greenlight Requirements and Process
 


### PR DESCRIPTION
- Moved component list earlier.
- Removed numbering (though kept 'component code' thing)
- Added Components section to the general and technical templates.

Note to @CPSTL, this one is a little more marginal based on the poll results in the forum. Even if you don't end up moving these, at least get rid of the numbering! 