### PR TITLE
Supporting materials

### DIFF
--- a/MIP0/mip0.md
+++ b/MIP0/mip0.md
@@ -24,6 +24,10 @@ Replaces: n/a
 **MIP0c9:** MIP Editor Removal Process  
 **MIP0c10:** Governance Facilitator Election Process  
 **MIP0c11:** Governance Facilitator Removal Process  
+**MIP0c12:** Supporting Materials  
+
+### References
+No referenced materials.
 
 ## Summary
 
@@ -227,6 +231,10 @@ Replaces: n/a
 
 A list of components that are included in the specification / proposal details.
 
+**References**
+
+A list of supporting materials referenced by this MIP.
+
 **Summary**
 
 A description of what the Maker Improvement Proposal (MIP) is focused on.
@@ -258,6 +266,10 @@ License: <added by MIP Author>
 **Components**
 
 A list of components that are included in the specification.
+
+**References**
+
+A list of supporting materials referenced by this MIP.
 
 **Summary**
 
@@ -514,3 +526,13 @@ Removal Form and Supporting Evidence
 	 -  Links to evidence further backing the motivation behind the removal of the Governance Facilitator.
 ```  
 ---
+
+### MIP0c12: Supporting Materials
+
+MIPs can optionally refer to external materials. External Materials must be added to the MIPs github in the same folder as the MIP which references them.
+
+Externally referenced materials are not MIP content, and are not ratified when a MIP becomes Accepted unless it is explicitly stated otherwise in a MIP Component specification.
+
+MIP References are named according to their parent MIP. The convention MIPXrY is used to refer to external materials. When referenced inline the reference should include both the reference code and the title and it should be bolded. For example: **MIPXrY - My Important Supporting Material**
+
+

--- a/MIP1/mip1.md
+++ b/MIP1/mip1.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP1c2:** The Initial Problem Space  
 **MIP1c3:** Changing the Problem Space  
 
+### References
+No referenced materials.
+
 ## Summary
 
 A Governance Paradigm is a complete and specific group of MIP Sets that solve an entire problem space. A problem space is defined as a list of issues that must be addressed in order for the Maker Protocol to be able to sustain itself and grow into the future Maker governance.

--- a/MIP10/mip10.md
+++ b/MIP10/mip10.md
@@ -19,6 +19,9 @@
 **MIP10c3:** Process for onboarding  
 **MIP10c4:** Process for offboarding  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal defines the process for onboarding, offboarding and managing oracles.

--- a/MIP11/mip11.md
+++ b/MIP11/mip11.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP11c3:** Process for Onboarding  
 **MIP11c4:** Process for offboarding  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal defines the process and requirements for risk teams to onboard general risk models for use in collateral onboarding in MIP12.

--- a/MIP12/mip12.md
+++ b/MIP12/mip12.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP12c2:** Proposing New Risk Parameters, Oracles, and Collateral Adapters  
 **MIP12c3:** Collateral Type Checklist (Governance)  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal defines the documentation requirements for the onboarding of a new collateral type to the Maker Protocol, more specifically, the risk teams' objectives and requirements to deliver it in a unified package risk construct.

--- a/MIP2/mip2.md
+++ b/MIP2/mip2.md
@@ -18,6 +18,9 @@ Replaces: n/a
 **MIP2c2:** Interim Phase 2  
 **MIP2c3:** MIP2 Obsolescence  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal details the process of how Maker Governance can bootstrap the setup and implementation of the first Governance Paradigm. More specifically, it defines two phases: 

--- a/MIP3/mip3.md
+++ b/MIP3/mip3.md
@@ -16,6 +16,9 @@ Replaces: n/a
 **MIP3c1:** Governance Cycle Breakdown  
 **MIP3c2:** Default Inclusion Threshold Modification Subproposals  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal formally introduces a Governance Cycle. The Governance Cycle provides a predictable framework for Maker Governance decisions. Furthermore, it provides participants (MKR holders) with a monthly overview of the decisions that are to be made, allowing participation despite time constraints.

--- a/MIP4/mip4.md
+++ b/MIP4/mip4.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP4c2:** MIP Amendment Process  
 **MIP4c3:** MIP Removal Process  
 
+### References
+No referenced materials.
+
 ## Summary
 
 The Amendment and Removal Process-MIP outlines the process for very small and relatively superficial changes to MIPs. This MIP Contains two Process Components, the first dealing with the Removal of ratified MIPs, and the second dealing with Amending current active MIPs.

--- a/MIP5/mip5.md
+++ b/MIP5/mip5.md
@@ -15,6 +15,9 @@ Replaces: n/a
 **MIP5c1:** Governance Facilitator Emergency Votes  
 **MIP5c2:** An Emergency State Change  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal defines an emergency voting system. Emergency votes are executive votes that can be initiated by any community member.

--- a/MIP6/mip6.md
+++ b/MIP6/mip6.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP6c2:** Application Form Template  
 **MIP6c3:** Sub Proposal Framework  
 
+### References
+No referenced materials.
+
 ## Summary
 
 The purpose of this proposal is to standardize the collateral onboarding form/forum template that community members and third-party projects can use to begin the process of getting their collateral onboarded to the Maker Protocol.

--- a/MIP7/mip7.md
+++ b/MIP7/mip7.md
@@ -18,6 +18,9 @@ Replaces: n/a
 **MIP7c3:** Domain Team onboarding  
 **MIP7c4:** Domain Team offboarding  
 
+### References
+No referenced materials.
+
 ## Summary
 
 The Domain Teams Onboarding & Offboarding proposal provides a predictable framework for both onboarding and offboarding domain teams required for the collateral onboarding process.

--- a/MIP8/mip8.md
+++ b/MIP8/mip8.md
@@ -14,6 +14,9 @@ Replaces: n/a
 ### Components
 **MIP8c1:** The Domain Greenlight Requirements and Process  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal aims to define the process where at least one domain team from each domain (Risk, Smart Contracts, Oracles, Legal, etc) "Greenlights" the collateral type (based on research) in order for the collateral onboarding process to proceed.

--- a/MIP9/mip9.md
+++ b/MIP9/mip9.md
@@ -17,6 +17,9 @@ Replaces: n/a
 **MIP9c1:** The Community Greenlight Requirements and Process  
 **MIP9c2:** Governance Poll Template  
 
+### References
+No referenced materials.
+
 ## Summary
 
 This proposal aims to standardize the process for allowing MKR Token Holders to inform the Domain Teams of their preferences for collateral types that have been proposed through MIP6. The preferences of the MKR Token holders are expressed in the form of an on-chain governance poll. The governance poll (Greenlight poll) runs at the end of the governance cycle and will run for a period of two weeks.


### PR DESCRIPTION
Added MIP0c12: Supporting Materials

- Added MIP0c12: Supporting Materials
- Added MIP0c12 to the MIP0 components list
- Modified the General MIPs template to include a References list.
- Modified the Technical MIPs template to include a References list.
- Added an empty References section to each MIP.
- Moved all mips into their own folders.

- Haven't touched any of the templates or created any external references yet.

@CPSTL It didn't make sense to include this component without moving the MIPs to their own folders, so I did that as part of this change. I also added a (currently empty) references list to each of the current MIPs. Everything in the change should be consistent. 

I like the idea of having templates be supporting materials that are explicitly called out and ratified in the main MIP. I'm happy to make that change if you agree it's a good idea.