### PR TITLE
Expanded summary sections to include sentence and component summaries.

### DIFF
--- a/mip0.md
+++ b/mip0.md
@@ -12,22 +12,48 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
-### Components
-**MIP0c1:** Definitions of the Maker Improvement Proposal Framework  
-**MIP0c2:** Core Principles  
-**MIP0c3:** The MIP Lifecycle  
-**MIP0c4:** MIP Components and MIP Component Types  
-**MIP0c5:** MIP Replacement Process  
-**MIP0c6:** MIP Templates  
-**MIP0c7:** MIP0 Domain Role Dependencies  
-**MIP0c8:** MIP Editor Election Process  
-**MIP0c9:** MIP Editor Removal Process  
-**MIP0c10:** Governance Facilitator Election Process  
-**MIP0c11:** Governance Facilitator Removal Process  
+## Sentence Summary
 
-## Summary
+MIP0 defines and describes the MIPs Framework. 
+
+## Paragraph Summary
 
 MIP0 is the genesis proposal describing the MIPs Framework. This includes the core components and statuses as well as the various MIP types and the overall MIP lifecycle. Furthermore, it provides the necessary tools, such as MIP templates, replacement processes, and dependencies. Lastly, the proposal details the key roles of the framework, the MIP Editor and the Governance Facilitator along with the process for adding and removing them.
+
+## Component Summary
+
+**MIP0c1: Definitions of the Maker Improvement Proposal Framework**  
+Defines several concepts that are important for understanding the MIPs process.
+
+**MIP0c2: Core Principles**  
+Discusses some core principles that all MIPs should aim to follow.
+
+**MIP0c3: The MIP Lifecycle**  
+Lays out how a MIP is created and moves through the process to become Accepted or Rejected.
+
+**MIP0c4: MIP Components and MIP Component Types**  
+Discusses the use of components to compartmentalize and organise MIPs
+
+**MIP0c5: MIP Replacement Process**  
+Discusses how MIPs can be replaced and the steps to be taken to maintain dependencies.
+
+**MIP0c6: MIP Templates**  
+Defines the MIP templates for both General and Technical MIPs.
+
+**MIP0c7: MIP0 Domain Role Dependencies**  
+Defines the core roles that the MIPs process requires to operate successfully.
+
+**MIP0c8: MIP Editor Election Process**  
+A process component that defines both the role and the process to elect a new MIP Editor.
+
+**MIP0c9: MIP Editor Removal Process**  
+A process component that defines both the criteria and the process to remove a MIP Editor.
+
+**MIP0c10: Governance Facilitator Election Process**  
+A process component that defines both the role and the process to elect a Governance Facilitator.
+
+**MIP0c11: Governance Facilitator Removal Process**  
+A process component that defines both the criteria and the process to remove a Governance Facilitator.
 
 
 ## Motivation
@@ -225,13 +251,17 @@ Date Proposed: <date created on, in (yyyy-mm-dd) format>
 Dependencies: n/a
 Replaces: n/a
 ```
-**Components**
+**Sentence Summary**
 
-A list of components that are included in the specification / proposal details.
+A description of what the Maker Improvement Proposal (MIP) is focused on. Suggest 30 words max.
 
-**Summary**
+**Paragraph Summary**
 
-A description of what the Maker Improvement Proposal (MIP) is focused on.
+A description of what the Maker Improvement Proposal (MIP) is focused on. Suggest 100 words max.
+
+**Component Summary**
+
+A description of the purpose of each component in the MIP . Suggest 30 words max per component.
 
 **Motivation**
 
@@ -257,13 +287,17 @@ Dependencies: <List of depdendent MIPs>
 Replaces: <List of MIP it is replacing>
 License: <added by MIP Author>
 ```
-**Components**
+**Sentence Summary**
 
-A list of components that are included in the specification.
+A description of what the Maker Improvement Proposal (MIP) is focused on. Suggest 30 words max.
 
-**Summary**
+**Paragraph Summary**
 
-A short description of what the Maker Improvement Proposal (MIP) is focused on.
+A description of what the Maker Improvement Proposal (MIP) is focused on. Suggest 100 words max.
+
+**Component Summary**
+
+A description of the purpose of each component in the MIP . Suggest 30 words max per component.
 
 **Motivation**
 

--- a/mip1.md
+++ b/mip1.md
@@ -12,14 +12,24 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
-### Components
-**MIP1c1:** Definitions  
-**MIP1c2:** The Initial Problem Space  
-**MIP1c3:** Changing the Problem Space  
+## Sentence Summary
 
-## Summary
+MIP1 defines and describes Governance Paradigms and problem spaces.
+
+## Paragraph Summary
 
 A Governance Paradigm is a complete and specific group of MIP Sets that solve an entire problem space. A problem space is defined as a list of issues that must be addressed in order for the Maker Protocol to be able to sustain itself and grow into the future Maker governance.
+
+## Component Summary
+
+**MIP1c1: Definitions**
+Defines what is meant by a problem space and a Governance Paradigm and describes the processes to change these.
+
+**MIP1c2: The Initial Problem Space**
+Defines an initial list of problems that will need to be solved in order for there to be a complete Governance Paradigm.
+
+**MIP1c3: Changing the Problem Space**
+A process component that provides a method and a template for adjusting the problem space.
 
 ## Motivation
 

--- a/mip10.md
+++ b/mip10.md
@@ -13,15 +13,27 @@
     Replaces: n/a
     
 
-### Components
-**MIP10c1:** Oracle Onboarding  
-**MIP10c2:** List of Active Oracle Data Models  
-**MIP10c3:** Process for onboarding  
-**MIP10c4:** Process for offboarding  
+## Sentence Summary
 
-## Summary
+MIP10 defines how oracles are onboarded, offboarded and managed in order to support the collateral onboarding process.
+
+## Paragraph Summary
 
 This proposal defines the process for onboarding, offboarding and managing oracles.
+
+## Component Summary
+
+**MIP10c1: Oracle Onboarding**  
+Defines a process for onboarding new oracles into the Maker Protocol.
+
+**MIP10c2: List of Active Oracle Data Models**  
+A list component that is kept up-to-date with the currently active oracle data models.
+
+**MIP10c3: Process for onboarding**  
+A process component that defines the method and template to be used to onboard new oracles for collateral assets.
+
+**MIP10c4: Process for offboarding**  
+A process component that defines the method and template to be used to offboard oracles in the case they have become obsolete or otherwise undesireable.
 
 ## Motivation
 

--- a/mip11.md
+++ b/mip11.md
@@ -11,15 +11,27 @@ Date Proposed: 2020-04-06
 Dependencies: MIP0, MIP3, MIP7
 Replaces: n/a
 ```
-### Components
-**MIP11c1:** General Risk Model Requirements  
-**MIP11c2:** List of Active General Risk Models  
-**MIP11c3:** Process for Onboarding  
-**MIP11c4:** Process for offboarding  
+## Sentence Summary
 
-## Summary
+MIP11 defines the requirements of general risk models and how they are onboarded to and offboarded from the Maker Protocol.
+
+## Paragraph Summary
 
 This proposal defines the process and requirements for risk teams to onboard general risk models for use in collateral onboarding in MIP12.
+
+## Component Summary
+
+**MIP11c1: General Risk Model Requirements**  
+Describes the concept of a general risk model and defines both the required components that all general risk models must have and optional components that a general risk model may have.
+
+**MIP11c2: List of Active General Risk Models**  
+A list component that is kept up-to-date with the currently active general risk models.
+
+**MIP11c3: Process for Onboarding**  
+A process component that defines a method and a template for onboarding a general risk model.
+
+**MIP11c4: Process for offboarding**  
+A process component that defines a method and a template for offboarding a general risk model.
 
 ## Motivation
 

--- a/mip12.md
+++ b/mip12.md
@@ -11,15 +11,24 @@ Date Proposed: 2020-04-06
 Dependencies: MIP0, MIP3, MIP7, MIP10, MIP11
 Replaces: n/a
 ```  
+## Sentence Summary
 
-### MIP11 Components
-**MIP12c1:** Domain Team Requirements for Onboarding Collateral Type to the Maker Protocol  
-**MIP12c2:** Proposing New Risk Parameters, Oracles, and Collateral Adapters  
-**MIP12c3:** Collateral Type Checklist (Governance)  
+MIP12 defines the domain team and documentation requirements for adding or changing collateral packages in the Maker Protocol.
 
-## Summary
+## Paragraph Summary
 
 This proposal defines the documentation requirements for the onboarding of a new collateral type to the Maker Protocol, more specifically, the risk teams' objectives and requirements to deliver it in a unified package risk construct.
+
+## Component Summary
+
+**MIP12c1: Domain Team Requirements for Onboarding Collateral Type to the Maker Protocol**  
+Lists the required and optional domain teams involved in onboarding a collateral type to the Maker Protocol.
+
+**MIP12c2: Proposing New Risk Parameters, Oracles, and Collateral Adapters**  
+A process component that defines a method, a template and the requirements for proposing new risk parameters, oracles or collateral adaptors.
+
+**MIP12c3: Collateral Type Checklist (Governance)**  
+Defines a checklist of actions that must be completed before and after governance approval of a collateral type.
 
 ## Motivation
 

--- a/mip2.md
+++ b/mip2.md
@@ -13,18 +13,28 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
-### Components
-**MIP2c1:** Interim Phase 1  
-**MIP2c2:** Interim Phase 2  
-**MIP2c3:** MIP2 Obsolescence  
+## Sentence Summary
 
-## Summary
+MIP2 details two interim phases during which logic defined in MIP0 is overriden.
+
+## Paragraph Summary
 
 This proposal details the process of how Maker Governance can bootstrap the setup and implementation of the first Governance Paradigm. More specifically, it defines two phases: 
 1. **Phase 1:** when a core governance framework is put in place and a functional collateral onboarding process is ratified.
 2. **Phase 2:** when the Problem Space is in the process of being addressed with MIPs and MIP Sets.
 
 Lastly, the proposal states that MIP2 itself will become obsolete when the Problem Space has officially been addressed. 
+
+## Component Summary
+
+**MIP2c1: Interim Phase 1**  
+Defines the first interim phase, in which the feedback period and freeze period for MIPs are ignored until both a core governance framework and a functional collateral onboarding process are implemented through MIPs.
+
+**MIP2c2: Interim Phase 2**  
+Defines the second interim phase, in which the feedback period and freeze period for MIPs are reduced until the initial problem space has been addressed.
+
+**MIP2c3: MIP2 Obsolescence**  
+Defines the obsolescence of this MIP once the interim phases have passed.
 
 
 ## Motivation

--- a/mip3.md
+++ b/mip3.md
@@ -12,13 +12,22 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
-### Components
-**MIP3c1:** Governance Cycle Breakdown  
-**MIP3c2:** Default Inclusion Threshold Modification Subproposals  
+## Sentence Summary
 
-## Summary
+MIP3 defines a monthly Governance Cycle with the aim of providing a predictable framework for Maker governance decisions.
+
+## Paragraph Summary
 
 This proposal formally introduces a Governance Cycle. The Governance Cycle provides a predictable framework for Maker Governance decisions. Furthermore, it provides participants (MKR holders) with a monthly overview of the decisions that are to be made, allowing participation despite time constraints.
+
+## Component Summary
+
+**MIP3c1: Governance Cycle Breakdown**  
+Breaks the Governance Cycle down into the actions that take place each week of the monthly cycle. 
+
+**MIP3c2: Default Inclusion Threshold Modification Subproposals**  
+A process component that defines a method and template for the modification of the default inclusion threshold.
+
 
 ## Motivation
 

--- a/mip4.md
+++ b/mip4.md
@@ -12,14 +12,24 @@ Dependencies: n/a
 Replaces: n/a
   ```
 
-### Components
-**MIP4c1:** Purpose Description  
-**MIP4c2:** MIP Amendment Process  
-**MIP4c3:** MIP Removal Process  
+## Sentence Summary
 
-## Summary
+MIP4 defines processes for the amendment and removal of accepted MIPs.
+
+## Paragraph Summary
 
 The Amendment and Removal Process-MIP outlines the process for very small and relatively superficial changes to MIPs. This MIP Contains two Process Components, the first dealing with the Removal of ratified MIPs, and the second dealing with Amending current active MIPs.
+
+## Component Summary
+
+**MIP4c1: Purpose Description**  
+Suggests the purpose of the amendment and removal processes and possible reasons for using each process.
+
+**MIP4c2: MIP Amendment Process**  
+A process component which defines a method and template for the amendment of an accepted MIP.
+
+**MIP4c3: MIP Removal Process**  
+A process component which defines a method and template for the removal of an accepted MIP.
 
 ## Motivation
 

--- a/mip5.md
+++ b/mip5.md
@@ -11,13 +11,22 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
-### Components
-**MIP5c1:** Governance Facilitator Emergency Votes  
-**MIP5c2:** An Emergency State Change  
 
-## Summary
+## Sentence Summary
+
+MIP5 defines emergency changes to the protocol and Governance Facilitator role and how they should be handled in practice.
+
+## Paragraph Summary
 
 This proposal defines an emergency voting system. Emergency votes are executive votes that can be initiated by any community member.
+
+## Component Summary
+
+**MIP5c1: Governance Facilitator Emergency Votes**  
+This component addresses the emergency removal of an individual from the Governance Facilitator role.
+
+**MIP5c2: An Emergency State Change**  
+This component addresses emergency state changes to the protocol and how they are to be handled by the Governance Facilitators.
 
 ## Motivation
 

--- a/mip6.md
+++ b/mip6.md
@@ -12,14 +12,24 @@ Dependencies: n/a
 Replaces: n/a
 ```
 
-### Components
-**MIP6c1:** Process Overview  
-**MIP6c2:** Application Form Template  
-**MIP6c3:** Sub Proposal Framework  
+## Sentence Summary
 
-## Summary
+MIP6 provides an overview of defines a standardised application form used to kick off the process of onboarding a new collateral asset to the Maker Protocol.
+
+## Paragraph Summary
 
 The purpose of this proposal is to standardize the collateral onboarding form/forum template that community members and third-party projects can use to begin the process of getting their collateral onboarded to the Maker Protocol.
+
+## Component Summary
+
+**MIP6c1: Process Overview**  
+Provides an overview of the collateral application form submission process which includes location, involved stakeholders and the next phase.
+
+**MIP6c2: Application Form Template**  
+Provides an collateral application form template to be used in the submission process defined in MIP6c1. 
+
+**MIP6c3: Sub Proposal Framework**  
+A process component that defines a method and template to amend the collateral application form template defined in MIP6c2.
 
 ## Motivation
 

--- a/mip7.md
+++ b/mip7.md
@@ -12,15 +12,27 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
-### Components
-**MIP7c1:** Domain Team Descriptions  
-**MIP7c2:** The Current Domain Roles List  
-**MIP7c3:** Domain Team onboarding  
-**MIP7c4:** Domain Team offboarding  
+## Sentence Summary
 
-## Summary
+MIP7 defines processes for onboarding and offboarding domain teams and members of those domain teams.
+
+## Paragraph Summary
 
 The Domain Teams Onboarding & Offboarding proposal provides a predictable framework for both onboarding and offboarding domain teams required for the collateral onboarding process.
+
+## Component Summary
+
+**MIP7c1: Domain Team Descriptions**  
+Describes the various domain teams and their responsibilities as they relate to the collateral onboarding process.
+
+**MIP7c2: The Current Domain Roles List**  
+A list component that is kept up-to-date with the currently ratified domain teams and their members.
+
+**MIP7c3: Domain Team onboarding**  
+A process component that defines a method and a template that allows the onboarding of domain teams and domain team members.
+
+**MIP7c4: Domain Team offboarding**  
+A process component that defines a method and a template that allows the offboarding of domain teams and domain team members.
 
 ## Motivation
 

--- a/mip8.md
+++ b/mip8.md
@@ -11,12 +11,19 @@ Date Proposed: 2020-04-06
 Dependencies: n/a
 Replaces: n/a
 ```
-### Components
-**MIP8c1:** The Domain Greenlight Requirements and Process  
 
-## Summary
+## Sentence Summary
+
+MIP8 defines the process by which domain teams signal that a potential collateral type is worth the time spent investigating its inclusion in the Maker Protocol.
+
+## Paragraph Summary
 
 This proposal aims to define the process where at least one domain team from each domain (Risk, Smart Contracts, Oracles, Legal, etc) "Greenlights" the collateral type (based on research) in order for the collateral onboarding process to proceed.
+
+## Component Summary
+
+**MIP8c1: The Domain Greenlight Requirements and Process**  
+Defines the process, requirements and possible outcomes from the domain greenlight process. 
 
 ## Motivation
 

--- a/mip9.md
+++ b/mip9.md
@@ -13,13 +13,21 @@ Dependencies: MIP6, MIP8
 Replaces: n/a
 ```
 
-### Components
-**MIP9c1:** The Community Greenlight Requirements and Process  
-**MIP9c2:** Governance Poll Template  
+## Sentence Summary
 
-## Summary
+MIP9 defines the process by which MKR Token Holders can signal their judgement on the value of a potential collateral type before domain teams spent time fully investigating its inclusion into the Maker Protocol.
+
+## Paragraph Summary
 
 This proposal aims to standardize the process for allowing MKR Token Holders to inform the Domain Teams of their preferences for collateral types that have been proposed through MIP6. The preferences of the MKR Token holders are expressed in the form of an on-chain governance poll. The governance poll (Greenlight poll) runs at the end of the governance cycle and will run for a period of two weeks.
+
+## Component Summary
+
+**MIP9c1: The Community Greenlight Requirements and Process**  
+Defines the process, requirements and possible outcomes from Community Greenlight process and the Governance Facilitators responsibilities in its operation.
+
+**MIP9c2: Governance Poll Template**  
+Defines a governance poll template to be used in the on-chain Community Greenlight poll.
 
 ## Motivation
 


### PR DESCRIPTION
- Changed General and Technical Template to include Sentence Summary, Paragraph Summary, Component Summary.
- Removed Component List and old Summary heading from the General and Technical templates.
- Changed all MIPs to follow the new templates.
- Wrote sentence summaries for each MIP.
- Paragraph Summaries for each MIP are a direct copy of the previous summaries.
- Wrote component summaries for each component in each MIP.

Component list I removed because it has too much overlap with Component Summary. Note that it may be a good idea to do that for the external reference list too if that PR is taken.

Component summaries are sometimes but not always superfluous, same for sentence summaries.

Some Paragraph summaries are too short, some are unclear, some are more motivation than summary. I'll try to cover those in another pass.