### PR TITLE
Add github action for writing to IPFS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: IPFS
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master, RFC, Accepted ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Upload to IPFS
+      uses: aquiladev/ipfs-action@v0.1.3
+      with:
+        # Directory path to upload
+        path: ../mips
+        # Type of target service to upload. Supported services [ipfs]
+        service: ipfs # optional, default is ipfs
+        # IPFS host
+        host: ipfs.komputing.org # optional, default is ipfs.komputing.org
+        # IPFS port
+        port: 443 # optional, default is 443
+        # IPFS protocol
+        protocol: https # optional, default is https
+        # Request timeout
+        timeout: 60000 # optional, default is 60000
+        # Level of verbosity
+        verbose: true


### PR DESCRIPTION
On push, for the master, RFC, and Accepted branches.

As you can see in the image this was uploaded to IPFS on push to master:

```
Upload to IPFS finished successfully QmbZHKiorNSnFmj2s9rNNLnPqiW4Ed6EF46JcS4EZjBMzP
```

[Here's a link](https://ipfs.io/ipfs/QmbZHKiorNSnFmj2s9rNNLnPqiW4Ed6EF46JcS4EZjBMzP) - the image is below. 


![image](https://user-images.githubusercontent.com/21752/85897021-18be9080-b7bf-11ea-9d9e-c3fb7f21c2a0.png)
