### PR TITLE
Updates to MIP14

### DIFF
--- a/MIP14/MIP14.md
+++ b/MIP14/MIP14.md
@@ -4,11 +4,11 @@
 ```
 MIP#: 14
 Title: Protocol DAI Transfer
-Author(s): @LongForWisdom @jtathmann
+Author(s): @LongForWisdom, @jtathmann
 Contributors: 
 Type: Process
-Status: Formal Submission (FS)
-Date Proposed: 2020-05-12
+Status: Request for Comments (RFC)
+Date Proposed: 2020-08-27
 Date Ratified: <yyyy-mm-dd>
 Dependencies: MIP0
 Replaces: N/A

--- a/MIP14/MIP14.md
+++ b/MIP14/MIP14.md
@@ -37,7 +37,7 @@ A process component that allows Maker Governance to transfer DAI from the Maker 
 A list component that lists the previous direct DAI transfers that have been made by the protocol in the past.
 
 **MIP14c4: Protocol DAI Transfer Ceiling**
-The maximum amount of DAI that can be transferred from the protocol in total.
+The maximum amount of DAI that can be transferred from the protocol in total using this process
 
 
 ## Motivation
@@ -110,6 +110,6 @@ Recipient Address: 0x0000000000000000000000000000000000000000
 ---
 
 **MIP14c4: Protocol DAI Transfer Ceiling** 
-MIP14c4 sets the maximum amount of DAI that can be transferred in total from the protocol.  MIP14c2-subproposals will not be eligible if they cause the historic amount of DAI transferred from the protocol to exceed the ceiling, which will be initially set to 250,000 DAI and can be modified by MIP14c4 subproposal **[MIP14c4-Subproposal-Template.md](MIP14c4-Subproposal-Template.md)**
+MIP14c4 sets the maximum amount of DAI that can be transferred in total from the protocol using this process.  MIP14c2-subproposals will not be eligible if they cause the historic amount of DAI transferred from the protocol to exceed the ceiling, which will be initially set to 250,000 DAI and can be modified by MIP14c4 subproposal **[MIP14c4-Subproposal-Template.md](MIP14c4-Subproposal-Template.md)**
 
 ---

--- a/MIP14/MIP14.md
+++ b/MIP14/MIP14.md
@@ -110,6 +110,6 @@ Recipient Address: 0x0000000000000000000000000000000000000000
 ---
 
 **MIP14c4: Protocol DAI Transfer Ceiling** 
-MIP14c4 sets the maximum amount of DAI that can be transferred in total from the protocol using this process.  MIP14c2-subproposals will not be eligible if they cause the historic amount of DAI transferred from the protocol to exceed the ceiling, which will be initially set to 250,000 DAI and can be modified by MIP14c4 subproposal **[MIP14c4-Subproposal-Template.md](MIP14c4-Subproposal-Template.md)**
+MIP14c4 sets the maximum amount of DAI that can be transferred in total from the protocol using this process.  MIP14c2-subproposals will not be eligible if they cause the historic amount of DAI transferred from the protocol to exceed the ceiling, which will be initially set to 250,000 DAI and can be modified by MIP14c4 subproposal. 
 
 ---

--- a/MIP14/MIP14.md
+++ b/MIP14/MIP14.md
@@ -4,8 +4,8 @@
 ```
 MIP#: 14
 Title: Protocol DAI Transfer
-Author(s): @LongForWisdom
-Contributors: @jtathmann
+Author(s): @LongForWisdom @jtathmann
+Contributors: 
 Type: Process
 Status: Formal Submission (FS)
 Date Proposed: 2020-05-12
@@ -37,7 +37,7 @@ A process component that allows Maker Governance to transfer DAI from the Maker 
 A list component that lists the previous direct DAI transfers that have been made by the protocol in the past.
 
 **MIP14c4: Protocol DAI Transfer Ceiling**
-The maximum amount of DAI that can be transferred from the protocol in total
+The maximum amount of DAI that can be transferred from the protocol in total.
 
 
 ## Motivation

--- a/MIP14/MIP14.md
+++ b/MIP14/MIP14.md
@@ -5,7 +5,7 @@
 MIP#: 14
 Title: Protocol DAI Transfer
 Author(s): @LongForWisdom
-Contributors: N/A
+Contributors: @jtathmann
 Type: Process
 Status: Formal Submission (FS)
 Date Proposed: 2020-05-12
@@ -15,6 +15,7 @@ Replaces: N/A
 ```
 ## References
 **[MIP14c2-Subproposal-Template.md](MIP14c2-Subproposal-Template.md)**
+**[MIP14c4-Subproposal-Template.md](MIP14c4-Subproposal-Template.md)**
 
 ## Sentence Summary
 
@@ -34,6 +35,9 @@ A process component that allows Maker Governance to transfer DAI from the Maker 
 
 **MIP14c3: Protocol DAI Transfer List**  
 A list component that lists the previous direct DAI transfers that have been made by the protocol in the past.
+
+**MIP14c4: Protocol DAI Transfer Ceiling**
+The maximum amount of DAI that can be transferred from the protocol in total
 
 
 ## Motivation
@@ -74,6 +78,8 @@ MIP14c2 subproposals have parameters that depend on the total amount of DAI to b
 - **Feedback Period:** 12 full weeks
 - **Frozen period:** 4 full weeks
 
+If a MIP14c2 subproposal would result in a FLOP auction, Governance Facilitator(s) will use established communication channels to ensure the community is informed
+
 MIP14c2 subproposals must use the template located at **[MIP14c2-Subproposal-Template.md](MIP14c2-Subproposal-Template.md)**. This template is considered ratified once this MIP moves to Accepted status.
 
 ---
@@ -83,7 +89,6 @@ This list can be amended through subproposals created under MIP14c2.
 
 **List Entry Template**
 Entries into this list should follow the following template:
-
 ```
 Reason:
 Sub-proposal Number: #
@@ -94,7 +99,6 @@ Recipient Address:
 
 **Historical Transfer List**
 There are currently no historical transfers. Below is an example transfer which should be removed (as should this paragraph) when the first ratified transfer is added to this list .
-
 ```
 Reason: Funding Chocolate for Governance Facilitators
 Sub-proposal Number: MIP14c1-SP0
@@ -102,5 +106,10 @@ Date Ratified: 2020-02-30
 Amount Transferred: 1,000,000 DAI
 Recipient Address: 0x0000000000000000000000000000000000000000
 ```
+
+---
+
+**MIP14c4: Protocol DAI Transfer Ceiling** 
+MIP14c4 sets the maximum amount of DAI that can be transferred in total from the protocol.  MIP14c2-subproposals will not be eligible if they cause the historic amount of DAI transferred from the protocol to exceed the ceiling, which will be initially set to 250,000 DAI and can be modified by MIP14c4 subproposal **[MIP14c4-Subproposal-Template.md](MIP14c4-Subproposal-Template.md)**
 
 ---

--- a/MIP14/MIP14c2-Subproposal-Template.md
+++ b/MIP14/MIP14c2-Subproposal-Template.md
@@ -23,6 +23,10 @@ Amount:
 
 - More details regarding the reason for the Protocol DAI Transfer.
 
+### Surplus Analysis
+
+- An analysis of whether the proposed transfer can be taken from the current surplus or if it would result in a FLOP auction.
+
 ### Targets
 
 - Clearly listed target addresses with matching amounts in the format:
@@ -30,7 +34,7 @@ Amount:
 Recipient Address: 0x0000000000000000000000000000000000000000
 Amount To Transfer: 0 DAI
 ```
-- Combined amount of DAI should not be higher than the Amount specified in the Preamble.
+- Combined amount of DAI should not be higher than the Amount specified in the Preamble nor exceed the DAI Transfer Ceiling.
 
 ### Relevant Information:
 

--- a/MIP14/MIP14c4-Subproposal-Template.md
+++ b/MIP14/MIP14c4-Subproposal-Template.md
@@ -1,0 +1,25 @@
+# MIP14c4: Subproposal for Protocol DAI Transfer Ceiling
+
+## Preamble
+```
+MIP14c4-SP#: #
+Author(s):
+Contributors:
+Status: 
+Date Proposed: <yyyy-mm-dd>
+Date Ratified: <yyyy-mm-dd>
+---
+```
+## Specification 
+
+## Transfer Ceiling Change
+
+- Maximum amount of DAI that can be transferred from the protocol in total
+
+### Context and Motivation
+
+- Why is the Protocol DAI Transfer Ceiling being changed?
+
+### Relevant Links
+    
+- Forum Discussions, etc


### PR DESCRIPTION
The main changes:

Adding MIP14c4: Dai Transfer Ceiling.  The maximum amount of DAI that can be transferred from the protocol in total using this process

Requiring Governance Facilitator(s) to communicate to the community that a FLOP would occur if the transfer proposal cannot be taken from the surplus

Adding a surplus analysis section to the MIP14c2 sub proposal template 

