### PR TITLE
Update MIP6 reference to forum categories

### DIFF
--- a/MIP6/mip6.md
+++ b/MIP6/mip6.md
@@ -52,7 +52,7 @@ Although this is only one component of the overall collateral onboarding process
 1.  Fill out the application/questions in as much detail as you're willing.
     
 
-    -   Once filled out, the application must be published on the official MakerDAO forum and should be posted within the `Collateral Onboarding App` subcategory within the `Maker Improvement Proposals` category.
+    -   Once filled out, the application must be published on the official MakerDAO forum and should be posted within the `Collateral Onboarding Applications (MIP6)` subcategory within the `Collateral Onboarding` category.
     -   This post should have the tag `collateral-app.`
     -   Note that an 'interested party' refers to anybody willing to act as a stakeholder for this onboarding process.
     


### PR DESCRIPTION
After reviewing the MIP6 document, I realized that it refers to categories in the Forum which doesn't exist (specifically `Collateral Onboarding App` is not a part of the `Maker Improvement Proposal` category). 

The proper subcategory is now under the `Collateral Onboarding` category

![image](https://user-images.githubusercontent.com/6622086/103312890-ac974080-4a1e-11eb-98b5-eaa930b33d67.png)
