### PR TITLE
Update MIP0c13-SP1.md

### DIFF
--- a/MIP0/MIP0c13-Subproposals/MIP0c13-SP1.md
+++ b/MIP0/MIP0c13-Subproposals/MIP0c13-SP1.md
@@ -5,7 +5,7 @@
 MIP0c13-SP#: 1
 Author(s): LongForWisdom
 Contributors: n/a
-Status: Formal Submission (FS)
+Status: Obsolete
 Date Proposed: 2020-08-20 
 Date Removed: 2020-09-10
 ---


### PR DESCRIPTION
Offboarding is now voluntary and does not go through Governance.
This subproposal is therefore obsolete.