### PR TITLE
Marking MIPs 35 and 36 as withdrawn

### DIFF
--- a/MIP35/mip35.md
+++ b/MIP35/mip35.md
@@ -7,7 +7,7 @@ Title: Peg Stability Module - Compound Mixed Exposure - With Farming
 Author(s): Alexis
 Contributors: None
 Type: Technical
-Status: Request for Comments (RFC)
+Status: Withdrawn
 Date Proposed: 2021-01-09
 Date Ratified: <yyyy-mm-dd>
 Dependencies: PSM, Uniswap, Vat, Join Usdc-lendler, Join Dai-lendler 

--- a/MIP36/mip36.md
+++ b/MIP36/mip36.md
@@ -7,7 +7,7 @@ Title: Peg Stability - Compound Governance Dai Leverage
 Author(s): Alexis
 Contributors: None
 Type: Technical
-Status: Request for Comments (RFC)
+Status: Withdrawn
 Date Proposed: 2021-01-09
 Date Ratified: <yyyy-mm-dd>
 Dependencies: Join Dai-farming, Join Dai-lendler 


### PR DESCRIPTION
MIPs [36](https://forum.makerdao.com/t/mip36-peg-stability-compound-governance-dai-leverage/6029/4) and [35](https://forum.makerdao.com/t/mip35-peg-stability-module-compound-mixed-exposure-with-farming/6024/44?u=blimpa) were withdrawn by author, @Davidutro, @CPSTL.