### PR TITLE
Replacing all variants with "RFC"

### DIFF
--- a/MIP13/MIP13c3-Subproposals/MIP13c3-SP11.md
+++ b/MIP13/MIP13c3-Subproposals/MIP13c3-SP11.md
@@ -3,7 +3,7 @@
     MIP13c3-SP#: 11
     Author(s): Yaron Velner (@yaronvel)
     Contributors: n/a
-    Status: Request for Comment (RFC)
+    Status: RFC
     Date Proposed: 2021-6-16
     Date Ratified: <yyyy-mm-dd>
     Declaration Statement: Onboarding a new collateral type backed by B.Protocol v2.

--- a/MIP26/mip26.md
+++ b/MIP26/mip26.md
@@ -6,7 +6,7 @@ MIP#: 26
 Title: DssGov - Governance Contract Redesign
 Author(s):  Smart Contracts Domain Team
 Type: Technical
-Status: Request for Comments (RFC)
+Status: RFC
 Date Proposed: 2020-10-06
 Dependencies: 
 Replaces: DSChief

--- a/MIP32/mip32.md
+++ b/MIP32/mip32.md
@@ -7,7 +7,7 @@ Title: Peg Stability Module - Compound Mixed Exposure
 Author(s): Alexis
 Contributors: None
 Type: Technical
-Status: Request for Comments (RFC)
+Status: RFC
 Date Proposed: 2020-12-18
 Date Ratified: <yyyy-mm-dd>
 Dependencies: PSM, Uniswap, Vat, Join Usdc-lendler, Join Dai-lendler 

--- a/MIP33/mip33.md
+++ b/MIP33/mip33.md
@@ -10,7 +10,7 @@ MIP#: 33
 Title: Maker Stability Price Module.
 Author(s):  Alexis
 Type: Technical
-Status: Request for Comments (RFC)
+Status: RFC
 Date Proposed: 2020-12-27
 Dependencies:
 Replaces: 

--- a/MIP37/mip37.md
+++ b/MIP37/mip37.md
@@ -7,7 +7,7 @@ MIP#: 37
 Title: Static Reserve For Governance
 Author(s):  Alexis
 Type: Technical
-Status: Request for Comments (RFC)
+Status: RFC
 Date Proposed: 2021-01-15
 Dependencies: None
 Replaces: Nothing

--- a/MIP39/MIP39c2-Subproposals/MIP39c2-SP17.md
+++ b/MIP39/MIP39c2-Subproposals/MIP39c2-SP17.md
@@ -7,7 +7,7 @@ MIP39c2-SP#: 17
 Author(s): @sorenpeter
 Contributors: @juanjuan
 Tags: dai-foundation, core-unit, daif-001, mandate
-Status: Request For Comments (RFC)
+Status: RFC
 Date Applied: 2021-07-07
 Date Ratified: <yyyy-mm-dd>
 ```

--- a/MIP4/MIP4c2-Subproposals/MIP4c2-SP11.md
+++ b/MIP4/MIP4c2-Subproposals/MIP4c2-SP11.md
@@ -8,7 +8,7 @@ MIP to be Amended: MIP24
 Author(s): @juanjuan
 Contributors: @elprogreso @iammeeoh
 Tags: mip-amendment, core-unit, emergency
-Status: Request For Comments (RFC)
+Status: RFC
 Date Proposed: 2021-01-18
 Date Ratified:
 Dependencies:

--- a/MIP4/MIP4c2-Subproposals/MIP4c2-SP5.md
+++ b/MIP4/MIP4c2-Subproposals/MIP4c2-SP5.md
@@ -8,7 +8,7 @@ MIP to be Amended: MIP12
 Author(s): Charles St.Louis (@CPSTL), Rune Christensen (@Rune23) 
 Contributors:
 Tags: mip-amendment, collateral-onboarding
-Status: Rejected (Failed Inclusion Poll July 2020)
+Status: Rejected
 Date Proposed: 2020-07-08
 Date Ratified: 
 ```

--- a/MIP40/MIP40c3-Subproposals/MIP40c3-SP24.md
+++ b/MIP40/MIP40c3-Subproposals/MIP40c3-SP24.md
@@ -7,7 +7,7 @@ MIP40c3-SP#: 24
 Author(s): @sorenpeter 
 Contributors: @juanjuan
 Tags: dai-foundation, core-unit, daif-001, budget
-Status: Request for Comments (RFC)
+Status: RFC
 Date Applied: 2021-07-07
 Date Ratified: YYYY-MM-DD
 ```

--- a/MIP41/MIP41c4-Subproposals/MIP41c4-SP18.md
+++ b/MIP41/MIP41c4-Subproposals/MIP41c4-SP18.md
@@ -7,7 +7,7 @@ MIP41c4-SP#: 18
 Author(s): @sorenpeter  
 Contributors: @juanjuan
 Tags: dai-foundation, core-unit, daif-001, facilitator
-Status: Request For Comments (RFC)
+Status: RFC
 Date Applied: 2021-07-07
 Date Ratified: YYYY-MM-DD
 ```

--- a/MIP7/MIP7c3-Subproposals/MIP7c3-SP1.md
+++ b/MIP7/MIP7c3-Subproposals/MIP7c3-SP1.md
@@ -8,7 +8,7 @@
 MIP7c3-SP#: 1
 Author: Mariano Conti
 Contributors: n/a
-Status: Request for Comments (RFC)
+Status: RFC
 Date Proposed: 2020-04-22
 Date Ratified:
 ---


### PR DESCRIPTION
I think making "RFC" the norm from now on solves the problem of having anomalous versions of it. Although the MIPs Portal is now able to pick up (most of) the variants that this PR corrects, I'm retroactively enforcing "RFC" for the sake of uniformity.