### PR TITLE
COM-001 budget numbers and description fix

### DIFF
--- a/MIP40/MIP40c3-Subproposals/MIP40c3-SP8.md
+++ b/MIP40/MIP40c3-Subproposals/MIP40c3-SP8.md
@@ -94,20 +94,20 @@ The Monthly Budget Statements will be added to the [team drive](https://drive.go
 
 ### Budget Breakdown
 
-_Please Note, Q3 2021 only covers the month of August, and includes some upfront costs. This budget assumes a July 2021 Governance Cycle ratification with August being our first month officially operating._
+_Please Note, Q3 2021 only covers the months of August and September, and includes some upfront costs. This budget assumes a July 2021 Governance Cycle ratification with August being our first month officially operating._
 
 |  Description  |  Annual  |  Q3 2021  |  Q4 2021  |
 |-|-|-|-|
-|  Salaries (3 positions)  |  $ 280,000.00  |  $ 23,333.33  |  $ 70,000.00  |
-|  Hourly Compensation  |  $ 40,000.00  |  $ 3,333.33  |  $ 10,000.00  |
-|  Healthcare  |  $ 43,200.00  |  $ 3,600.00  |  $ 10,800.00  |
+|  Salaries (3 positions)  |  $ 280,000.00  |   $ 46,666.66  |  $ 70,000.00  |
+|  Hourly Compensation  |  $ 40,000.00  |  $ 6,666.66  |  $ 10,000.00  |
+|  Healthcare  |  $ 43,200.00  |  $ 7,200.00  |  $ 10,800.00  |
 |  Sign-on Expenses  |  $ 1,800.00  |  $ 1,800.00  |  $ -    |
-|  Travel & Events  |  $ 10,000.00  |  $ 833.33  |  $ 2,500.00  |
-|  Operating Expenses  |  $ 11,000.00  |  $ 916.67  |  $ 2,750.00  |
-|  Professional Services  |  $ 50,000.00  |  $ 4,166.67  |  $ 12,500.00  |
-|  Contingency Buffer  |  $ 50,000.00  |  $ 4,166.67  |  $ 12,500.00  |
+|  Travel & Events  |  $ 10,000.00  |  $ 1,666.68  |  $ 2,500.00  |
+|  Operating Expenses  |  $ 11,000.00  |  $ 1,833.34  |  $ 2,750.00  |
+|  Professional Services  |  $ 50,000.00  |  $ 8,333.33  |  $ 12,500.00  |
+|  Contingency Buffer  |  $ 50,000.00  |  $ 8,333.33  |  $ 12,500.00  |
 |  |  |  |  |
-|  Total  |  $ 486,000.00  |  $ 42,150.00  |  $ 121,050.00  |
+|  Total  |  $ 486,000.00  |  $ 82,500.00  |  $ 121,050.00  |
 |  Approximate Per month  |  $ 40,500.00  |  |  |
 
 #### Details

--- a/MIP40/MIP40c3-Subproposals/MIP40c3-SP8.md
+++ b/MIP40/MIP40c3-Subproposals/MIP40c3-SP8.md
@@ -18,7 +18,7 @@ MIP40c3-SP8 adds the budget for Core Unit COM-001: Governance Communications.
 
 ## Paragraph Summary
 
-This initial budget, for 163,200 Dai, provides five months of runway, August 2021 - Dec 2021. In the next year, we intend to submit bi-annual budgets, covering 6 months at a time unless otherwise preferred by MakerDAO. The annual budget figure is $486,000.
+This initial budget, for 203,550 Dai, provides five months of runway, August 2021 - Dec 2021. In the next year, we intend to submit bi-annual budgets, covering 6 months at a time unless otherwise preferred by MakerDAO. The annual budget figure is $486,000.
 
 A vote to ratify this MIP means MKR holders make a commitment to:
 


### PR DESCRIPTION
Hi folks,

In reviewing COM-001's original sub proposal an error was uncovered. Q3 numbers counted for one month of expenses rather than two (Aug +Sep.) I made the fixes in this PR. This change does not affect what MKR voters agreed to--funding our team for five months; but it does change the presented numbers.

As a result of this error our budget stream is misconfigured. We could arrange for a lump sum or cut this stream and create a new one. The simplest solution in my opinion is to grant a lump sum for the missing month.

Please advise on how to move forward.

@blimpa @prose11 @LongForWisdom 

Also as a side-note, we are way under budget due to the lack of a third FTE and also no health insurance expense for August and September due to delays in the setup process. I am in the process of writing a budget modification to adjust our numbers and to  extend continuous funding through to 06/22