### PR TITLE
Fix monthly budget number

### DIFF
--- a/MIP40/MIP40c3-Subproposals/MIP40c3-SP53.md
+++ b/MIP40/MIP40c3-Subproposals/MIP40c3-SP53.md
@@ -118,7 +118,7 @@ To enable this payment flow, the following configuration of the TECH-001 Operati
 
 ### Budget Breakdown
 
-The yearly budget cap request for the TechOps Core Unit is 2,566,200 DAI. This equates to a monthly budget cap of 213,850 DAI to support the team mandate.
+The yearly budget cap request for the TechOps Core Unit is 2,566,200 DAI. This equates to a monthly budget cap of 207,200 DAI to support the team mandate.
 
 This budget cap secures a team of 5.7 full-time employees (FTE), critical infrastructure and tools, as well as covers all other operational costs listed in the table below.
 


### PR DESCRIPTION
The previous 213,850 DAI amount was incorrectly calculated for the monthly budget cap under “Budget Breakdown”.

The yearly budget cap request for the TechOps Core Unit is 2,486,400 DAI. This equates to a monthly budget cap of 207,200 DAI to support the team mandate. This has now been corrected.