### PR TITLE
Add 1 MKR requirement for Facilitator Offboarding

### DIFF
--- a/MIP41/MIP41c5-Subproposal-Template.md
+++ b/MIP41/MIP41c5-Subproposal-Template.md
@@ -22,6 +22,11 @@ Date Ratified: <yyyy-mm-dd>
 
 - Why are you proposing to offboard this Facilitator?
 
+### MKR Stake
+
+- Please post the transaction ID on Ethereum where you have sent 1 MKR to the pause proxy. (0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB)
+- Please post the message of the form "@XXXX is offboarding @YYYY. <LINK TO FORUM POST>" along with the associated signature from the EOA.
+
 ### Core Unit ID
 
 - Please specify the Core Unit ID.

--- a/MIP41/MIP41c5-Subproposal-Template.md
+++ b/MIP41/MIP41c5-Subproposal-Template.md
@@ -24,6 +24,7 @@ Date Ratified: <yyyy-mm-dd>
 
 ### MKR Stake
 
+- Link to passed signal request to bypass this check (if necessary)
 - Please post the transaction ID on Ethereum where you have sent 1 MKR to the pause proxy. (0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB)
 - Please post the message of the form "@XXXX is offboarding @YYYY. <LINK TO FORUM POST>" along with the associated signature from the EOA.
 

--- a/MIP41/mip41.md
+++ b/MIP41/mip41.md
@@ -120,6 +120,10 @@ This process component allows Governance to offboard a Facilitator.
 
 Depending on the Core Unit's Budget Implementations, this Subproposal may include a technical state change to remove control of the Budget Implementations from the offboarded Facilitator.
 
+For the offboarding proposal to be valid, proposers must transfer 1 MKR to the pause proxy (0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB) from an EOA and sign a message with that same EOA saying `@XXXX is offboarding @YYYY. <LINK TO FORUM POST>` where @XXXX is the proposer and @YYYY is the facilitator to be offboarded. The link to the forum will be the link to the offboarding proposal. Signed messages can be made with the Etherscan tool: https://etherscan.io/verifiedSignatures
+
+This 1 MKR stake will be transferred back to the proposer upon successful offboarding at the next available executive. If the proposal fails then the 1 MKR is forfeit from the proposer and left in the control of governance.
+
 The proposal parameters are:
 * Minimum feedback period: 1 month
 * Minimum frozen period: 1 week

--- a/MIP41/mip41.md
+++ b/MIP41/mip41.md
@@ -124,6 +124,10 @@ For the offboarding proposal to be valid, proposers must transfer 1 MKR to the p
 
 This 1 MKR stake will be transferred back to the proposer upon successful offboarding at the next available executive. If the proposal fails then the 1 MKR is forfeit from the proposer and left in the control of governance.
 
+Alternatively, the proposer can run a signal request which upon success allows an offboarding proposal to proceed without a 1 MKR requirement. The signal request must be specific to the facilitator that will later be offboarded with this MIP41c5.
+
+Facilitators are free to offboard themselves voluntarily with no requirements or vote.
+
 The proposal parameters are:
 * Minimum feedback period: 1 month
 * Minimum frozen period: 1 week


### PR DESCRIPTION
This makes the voluntary offboarding language more clear, adds a 1 MKR requirement for offboarding along with a bypass via Signal Request.

https://forum.makerdao.com/t/mip4c2-spxx-mip41-facilitator-offboarding-amendment/16297