### PR TITLE
Adding the RWA Foundation to the active list

### DIFF
--- a/MIP58/MIP58.md
+++ b/MIP58/MIP58.md
@@ -182,6 +182,11 @@ Address:
 ```
 
 **Active RWA Foundations List**
+```
+Legal entity name: RWA Foundation
+Company No: 381281
+Address: Silverside Management Ltd., Whitehall Chambers, 2nd Floor Whitehall House, 238 North Church Street, George Town, Cayman Islands
+```
 
 ### MIP58c4: Generic DAO Resolution
 


### PR DESCRIPTION
This is just a housekeeping exercise to document which is the only RWA Foundation that Maker has available. This Foundation is providing service only to HVB deal for now.

To verify the information i'm providing in the PR is correct, please, check the 2 of the GDOCS in this forum post: https://forum.makerdao.com/t/rwa-foundation-001-rwa-foundation/11066


1.- The name and company number is defined at the top of this document "2021-10-05 - Launch resolutions" 2.- The address is defined in Paragraph 6 (top of page 2) of the "Memorandum of Association" document.