### PR TITLE
update action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Upload to IPFS
-      uses: aquiladev/ipfs-action@v0.1.3
+      uses: aquiladev/ipfs-action@master
       with:
         # Directory path to upload
         path: ../mips


### PR DESCRIPTION
Since node12 is deprecated we need to update the github action that uses it. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

for `aquiladev/ipfs-action` the current `v0.1.3` is 3 years old. update to master which is the latest version.

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru