### PR TITLE
Added HKUST_EPI_BLOCKCHAIN to unaffiliated AVC member list. 

### DIFF
--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -155,7 +155,7 @@ List of Unaffiliated AVC Members:
 |---|---|---|---|---:|
 | TRUEMAKER | [0x4eFb12d515801eCfa3Be456B5F348D3CD68f9E8a](https://etherscan.io/address/0x4efb12d515801ecfa3be456b5f348d3cd68f9e8a) | [Link](https://forum.makerdao.com/t/growth-cvc-membership-submission-request/20349) | [Link](https://etherscan.io/verifySig/16549) | 5.016 |
 | anathem.eth | [0xa2fC3b7A5dA35D0418Ec46A9CcFc7f4a53084841](https://etherscan.io/address/0xa2fC3b7A5dA35D0418Ec46A9CcFc7f4a53084841) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-anathem-eth/20558/2) | [Link](https://etherscan.io/verifySig/16935) | 0.313 |
-| seedlatam.eth | [0x0087a081a9b430fd8f688c6ac5dd24421bfb060d](https://etherscan.io/address/0x0087a081a9b430fd8f688c6ac5dd24421bfb060d) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-submission-seedlatam-eth/20836) | [Link](https://etherscan.io/verifySig/18891) | 1.040 |
+| HKUST_EPI_BLOCKCHAIN | [0xE4594A66d9507fFc0d4335CC240BD61C1173E666](https://etherscan.io/address/0x0087a081a9b430fd8f688c6ac5dd24421bfb060d) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-hkust-epi-blockchain/20939) | [Link](https://etherscan.io/tx/0xc11f93b290673c5348400adfdab516f08b2fb7f3197dd024a2cc94a301243216) | 1.007 |
 
 ¤¤¤
 

--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -155,7 +155,7 @@ List of Unaffiliated AVC Members:
 |---|---|---|---|---:|
 | TRUEMAKER | [0x4eFb12d515801eCfa3Be456B5F348D3CD68f9E8a](https://etherscan.io/address/0x4efb12d515801ecfa3be456b5f348d3cd68f9e8a) | [Link](https://forum.makerdao.com/t/growth-cvc-membership-submission-request/20349) | [Link](https://etherscan.io/verifySig/16549) | 5.016 |
 | anathem.eth | [0xa2fC3b7A5dA35D0418Ec46A9CcFc7f4a53084841](https://etherscan.io/address/0xa2fC3b7A5dA35D0418Ec46A9CcFc7f4a53084841) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-anathem-eth/20558/2) | [Link](https://etherscan.io/verifySig/16935) | 0.313 |
-| HKUST_EPI_BLOCKCHAIN | [0xE4594A66d9507fFc0d4335CC240BD61C1173E666](https://etherscan.io/address/0x0087a081a9b430fd8f688c6ac5dd24421bfb060d) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-hkust-epi-blockchain/20939) | [Link](https://etherscan.io/tx/0xc11f93b290673c5348400adfdab516f08b2fb7f3197dd024a2cc94a301243216) | 1.007 |
+| HKUST_EPI_BLOCKCHAIN | [0xE4594A66d9507fFc0d4335CC240BD61C1173E666](https://etherscan.io/address/0xE4594A66d9507fFc0d4335CC240BD61C1173E666) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-hkust-epi-blockchain/20939) | [Link](https://etherscan.io/tx/0xc11f93b290673c5348400adfdab516f08b2fb7f3197dd024a2cc94a301243216) | 1.007 |
 
 ¤¤¤
 


### PR DESCRIPTION
Removed seedlatam.eth from this list, as they are now affiliated with Sovereign Finance AVC.