### PR TITLE
MIP102c2 template revision

### DIFF
--- a/MIP102/MIP102c2-Subproposal-Template.md
+++ b/MIP102/MIP102c2-Subproposal-Template.md
@@ -20,7 +20,9 @@ A MIP102c2 Subproposal must be _either_ 1) an Article 1 Edit _or_ a 2) General E
 
 If your MIP102c2 Subproposal seeks to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered an Article 1 edit and cannot seek to amend any content except for Article 1.
 
-If your MIP102c2 Subproposal does not seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered a General Edit. An MIP102c2 General edit cannot modify Article 1 elements.
+If your MIP102c2 Subproposal does not seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered a General Edit. An MIP102c2 General Edit cannot modify Article 1 elements.
+
+Please indicate in the Preamble whether your MIP102c2 Subproposal is an Article 1 Edit or a General Edit. 
 
 If you seek to make Article 1 edits as well as General Edits to an Alignment Artifact, you must submit two separate MIP102c2 Subproposals.
 

--- a/MIP102/MIP102c2-Subproposal-Template.md
+++ b/MIP102/MIP102c2-Subproposal-Template.md
@@ -7,12 +7,22 @@ MIP102c2-SP#: #
 MIP to be amended: <MIP#>
 Author(s):
 Contributors:
+General Edit or Article 1 Edit:
 Tags: template
 Status:
 Date Proposed: <yyyy-mm-dd>
 Date Ratified: <yyyy-mm-dd>
 ```
+
 ## Specification
+
+A MIP102c2 Subproposal must be either 1) an Article 1 Edit or a 2) General Edit.
+
+If you seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, please indicate this in the Preamble. An MIP102c2 Article 1 edit cannot seek to amend any content except for Article 1.
+
+If your MIP102c2 Subproposal does not seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered a General Edit. An MIP102c2 General edit cannot modify Article 1 elements.
+
+If you seek to make Article 1 edits as well as General Edits to an Alignment Artifact, you must submit two separate MIP102c2 Subproposals.
 
 ### Motivation
 

--- a/MIP102/MIP102c2-Subproposal-Template.md
+++ b/MIP102/MIP102c2-Subproposal-Template.md
@@ -16,7 +16,7 @@ Date Ratified: <yyyy-mm-dd>
 
 ## Specification
 
-A MIP102c2 Subproposal must be either 1) an Article 1 Edit or a 2) General Edit.
+A MIP102c2 Subproposal must be _either_ 1) an Article 1 Edit _or_ a 2) General Edit.
 
 If you seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, please indicate this in the Preamble. An MIP102c2 Article 1 edit cannot seek to amend any content except for Article 1.
 

--- a/MIP102/MIP102c2-Subproposal-Template.md
+++ b/MIP102/MIP102c2-Subproposal-Template.md
@@ -18,7 +18,7 @@ Date Ratified: <yyyy-mm-dd>
 
 A MIP102c2 Subproposal must be _either_ 1) an Article 1 Edit _or_ a 2) General Edit.
 
-If you seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, please indicate this in the Preamble. An MIP102c2 Article 1 edit cannot seek to amend any content except for Article 1.
+If your MIP102c2 Subproposal seeks to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered an Article 1 edit and cannot seek to amend any content except for Article 1.
 
 If your MIP102c2 Subproposal does not seek to amend Article 1 of a Scope Bounded Mutable Alignment Artifact, it is considered a General Edit. An MIP102c2 General edit cannot modify Article 1 elements.
 


### PR DESCRIPTION
MIP102c2 template revision that:

1. Adds a field in the Preamble for authors to specify whether it is an Article 1 Edit or a General Edit
2. Adds explanatory text regarding the aforementioned types of edits under Specification