### PR TITLE
Update MIP113 5.2.4.7.1A

### DIFF
--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -448,15 +448,16 @@ List of active AVCs and their members:
 
 List of pending AVCs and their members:
 
+
+---
+
+List of inactive AVCs and their members prior to becoming inactive:
+
 [**RISK AVC**](https://forum.makerdao.com/t/cvc-application-risk-cvc/20948)
 
 | AVC Member Name | AVC Member Address | Forum Verification | Verified Signature | Verified MKR Holding (MKR) (3dp) | Approved to Join AVC |
 |---|---|---|---|---:|---|
 | HKUST_EPI_BLOCKCHAIN | [0xE4594A66d9507fFc0d4335CC240BD61C1173E666](https://etherscan.io/address/0xE4594A66d9507fFc0d4335CC240BD61C1173E666) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-hkust-epi-blockchain/20939) | [Link](https://etherscan.io/tx/0xc11f93b290673c5348400adfdab516f08b2fb7f3197dd024a2cc94a301243216) | 1.007 | [AVC Creator](https://forum.makerdao.com/t/cvc-application-risk-cvc/20948) |
-
----
-
-List of inactive AVCs and their members prior to becoming inactive:
 
 [**Composable AVC**](https://forum.makerdao.com/t/cvc-registration-submission-composable-cvc/20348)
 


### PR DESCRIPTION
Reclassify the RISK AVC as 'Inactive' for reasons stated in MIP 113 5.2.4.3 - Place the RISK AVC in this category until the end of Q4, as justified in 5.2.4.5