### PR TITLE
Update MIP113.md

### DIFF
--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -383,7 +383,7 @@ An AVC is marked as _active_ status if it has fulfilled every requirement under 
 ---
 ##### 5.2.4.2
 
-An AVC is marked as _inactive_ status if it has failed to fulfill the requirements under *ATL101 2.5.4* for the most recent quarter, but has fulfilled the requirements for one or more prior quarters.
+An AVC is marked as _inactive_ status if it has failed to fulfil the requirements under *2.5.4* of The Atlas for the most recent quarter, but has fulfilled the requirements for one or more prior quarters.
 
 ---
 ##### 5.2.4.3

--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -370,7 +370,7 @@ List of Unaffiliated AVC Members:
 
 #### 5.2.3
 
-An Unaffiliated AVC Member may join an AVC through the process described in MIP113 5.2.1.1 or start a new AVC through the process described in MIP101 2.5.3.
+An Unaffiliated AVC Member may join an AVC through the process described in *5.2.1.1* or start a new AVC through the process described in *2.5.3* of The Atlas.
 
 #### 5.2.4: AVC Management
 

--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -312,11 +312,11 @@ AVC splits are disabled until the launch of NewChain.
 
 #### 5.2.1
 
-To become recognized as an Unaffiliated AVC Member, an Ecosystem Actor must post a recognition submission message publicly on the Maker Governance Forum.
+To become recognized as an Unaffiliated AVC Member or to join an existing AVC, an Alignment Conserver must post a recognition submission message publicly on the Maker Governance Forum.
 
 ##### 5.2.1.1
 
-A recognition submission message must be cryptographically signed by an Ethereum address containing at least 1 MKR, or that has delegated at least 1 MKR.
+A recognition submission message must be cryptographically signed by an Ethereum address containing at least 1 MKR, or that has delegated at least 1 MKR. This condition must be met during all mandate statuses, including 'active' and 'pending'.
 
 ##### 5.2.1.2
 
@@ -370,7 +370,7 @@ List of Unaffiliated AVC Members:
 
 #### 5.2.3
 
-An Unaffiliated AVC Member may join an AVC through the process described in 4.5 or start a new AVC through the process described in 4.4.
+An Unaffiliated AVC Member may join an AVC through the process described in MIP113 5.2.1.1 or start a new AVC through the process described in MIP101 2.5.3.
 
 #### 5.2.4: AVC Management
 
@@ -378,12 +378,12 @@ The Governance Facilitators must monitor and record the status of each AVC.
 
 ##### 5.2.4.1
 
-An AVC is marked as _active_ status if it has fulfilled every requirement under *4.3* in the previous quarter.
+An AVC is marked as _active_ status if it has fulfilled every requirement under *MIP101 2.5.4* in the previous quarter.
 
 ---
 ##### 5.2.4.2
 
-An AVC is marked as _inactive_ status if it has failed to fulfill the requirements under *4.3* for the most recent quarter, but has fulfilled the requirements for one or more prior quarters.
+An AVC is marked as _inactive_ status if it has failed to fulfill the requirements under *ATL101 2.5.4* for the most recent quarter, but has fulfilled the requirements for one or more prior quarters.
 
 ---
 ##### 5.2.4.3
@@ -449,15 +449,15 @@ List of active AVCs and their members:
 
 List of pending AVCs and their members:
 
+---
+
+List of inactive AVCs and their members prior to becoming inactive:
+
 [**RISK AVC**](https://forum.makerdao.com/t/cvc-application-risk-cvc/20948)
 
 | AVC Member Name | AVC Member Address | Forum Verification | Verified Signature | Verified MKR Holding (MKR) (3dp) | Approved to Join AVC |
 |---|---|---|---|---:|---|
 | HKUST_EPI_BLOCKCHAIN | [0xE4594A66d9507fFc0d4335CC240BD61C1173E666](https://etherscan.io/address/0xE4594A66d9507fFc0d4335CC240BD61C1173E666) | [Link](https://forum.makerdao.com/t/cvc-member-recognition-hkust-epi-blockchain/20939) | [Link](https://etherscan.io/tx/0xc11f93b290673c5348400adfdab516f08b2fb7f3197dd024a2cc94a301243216) | 1.007 | [AVC Creator](https://forum.makerdao.com/t/cvc-application-risk-cvc/20948) |
-
----
-
-List of inactive AVCs and their members prior to becoming inactive:
 
 [**Composable AVC**](https://forum.makerdao.com/t/cvc-registration-submission-composable-cvc/20348)
 

--- a/MIP113/MIP113.md
+++ b/MIP113/MIP113.md
@@ -378,7 +378,7 @@ The Governance Facilitators must monitor and record the status of each AVC.
 
 ##### 5.2.4.1
 
-An AVC is marked as _active_ status if it has fulfilled every requirement under *MIP101 2.5.4* in the previous quarter.
+An AVC is marked as _active_ status if it has fulfilled every requirement under *2.5.4* of The Atlas in the previous quarter.
 
 ---
 ##### 5.2.4.2


### PR DESCRIPTION
MIP113 5.2.1 
Include “or to join an existing AVC” to the sentence. As stated in  5.2.1.2.4.

MIP113 5.2.3
Replace reference “4.5” for MIP113 5.2.1.2.4 and “4.4” for MIP101 2.5.3

MIP113 5.2.4.2
Replace reference “4.3” for MIP101 5.2.4.2

MIP113 5.2.1.1
Include context to 5.2.1.1 - "The condition must be met during all the mandate". As stated in ATL2.5.4.2

MIP113 5.2.1 
Replace "Ecosystem Actor " for "Alignment Conserver" - As stated in ATL2.5.3.1

MIP113 5.2.4.6.1A
Reclassify the RISK AVC as 'Inactive' for reasons stated in MIP113 5.2.4.2 - Place the RISK AVC in this category until the end of Q4, as justified in MIP 113 5.2.4.5

MIP113 5.2.4.2
Update reference from ”*4.3”* to ATL101 2.5.4.