### PR TITLE
TECH-2595 - Improve / fix the IPFS deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,39 +1,41 @@
-# This is a basic workflow to help you get started with Actions
+name: Deploy to IPFS
 
-name: IPFS
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    branches: [ master, RFC, Accepted ]
+    branches:
+      - master
+      - TECH-*
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  deploy:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    environment: prod
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-    - name: Upload to IPFS
-      uses: aquiladev/ipfs-action@master
-      with:
-        # Directory path to upload
-        path: ../mips
-        # Type of target service to upload. Supported services [ipfs]
-        service: ipfs # optional, default is ipfs
-        # IPFS host
-        host: ipfs.komputing.org # optional, default is ipfs.komputing.org
-        # IPFS port
-        port: 443 # optional, default is 443
-        # IPFS protocol
-        protocol: https # optional, default is https
-        # Request timeout
-        timeout: 60000 # optional, default is 60000
-        # Level of verbosity
-        verbose: true
+      - name: Deploy to IPFS
+        id: ipfs
+        uses: aquiladev/ipfs-action@master
+        with:
+          path: ../mips
+          service: filebase
+          pinName: 'mips-${{ vars.ENV }}'
+          filebaseBucket: ${{ secrets.FILEBASE_BUCKET }}
+          filebaseKey: ${{ secrets.FILEBASE_KEY }}
+          filebaseSecret: ${{ secrets.FILEBASE_SECRET }}
+
+      - name: Update DNSLink record in Cloudflare
+        id: cloudflare-dnslink
+        run: |
+          curl --request PATCH \
+            --url https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/web3/hostnames/${{ secrets.CLOUDFLARE_HOSTNAME_ID }} \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H 'Content-Type: application/json' \
+            --data '{
+            "description": "DNS record for MIPs on IPFS",
+            "dnslink": "/ipfs/${{ steps.ipfs.outputs.cid }}"
+          }'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - TECH-*
 
 jobs:
   deploy:
@@ -20,7 +21,7 @@ jobs:
         id: ipfs
         uses: aquiladev/ipfs-action@master
         with:
-          path: ../mips
+          path: ../mips/MIP*
           service: filebase
           pinName: 'mips-${{ vars.ENV }}'
           filebaseBucket: ${{ secrets.FILEBASE_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - TECH-*
 
 jobs:
   deploy:
@@ -16,12 +15,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          sparse-checkout: |
+            MIP*
+          sparse-checkout-cone-mode: false
 
       - name: Deploy to IPFS
         id: ipfs
         uses: aquiladev/ipfs-action@master
         with:
-          path: ../mips/MIP*
+          path: ../mips
           service: filebase
           pinName: 'mips-${{ vars.ENV }}'
           filebaseBucket: ${{ secrets.FILEBASE_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - TECH-*
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Maker Improvement Proposals are the preferred mechanism for improving both Maker Governance and the Maker Protocol.
 
-Through an open and documented process, community feedback will be collected to reach the broadest possible consensus on how the MakerDAO should evolve. Furthermore, MIPs provide a mechanism for any community member to define key issues and suggest changes and additions to the system. The MIPs process is conducted with a high level of transparency, rigor, and community input in order to minimize undesirable results. 
+Through an open and documented process, community feedback will be collected to reach the broadest possible consensus on how the MakerDAO should evolve. Furthermore, MIPs provide a mechanism for any community member to define key issues and suggest changes and additions to the system. The MIPs process is conducted with a high level of transparency, rigor, and community input in order to minimize undesirable results.
 
 For a current and historical view of proposed MIPs, please check out the [MIPs Portal](https://mips.makerdao.com/). In short, the portal should be the go-to resource for anyone wanting to explore MIPs (and the subproposals derived from them) in a reader-friendly manner. The Portal features smart-linking, on-hover previews, predefined common queries (Views), and advanced queries with logical operators and filters.
 
@@ -24,9 +24,9 @@ Just like MIPs, subproposals are standardized documents subject to voting. Once 
 
 ## Authoring and Proposing
 
-In the spirit of DAOs, MIPs and subproposals can be brought forth and proposed by anyone. 
+In the spirit of DAOs, MIPs and subproposals can be brought forth and proposed by anyone.
 
-If you're interested in proposing a MIP or think you might in the future, continue reading below for a quick overview of the process and how to get started. 
+If you're interested in proposing a MIP or think you might in the future, continue reading below for a quick overview of the process and how to get started.
 
 ### Getting Started with MIPs (For Authors)
 
@@ -36,7 +36,7 @@ MIPs are written using Markdown and hosted on GitHub. You can always count on MI
 
 Markdown is a very simple markup language for formatting text, i.e., adding headers, bullet lists, italicized text, et cetera. When working with MIPs, you should use GitHub-flavored Markdown.
 
-> [GitHub’s Mastering Markdown](https://guides.github.com/features/mastering-markdown/) will get you up to speed in no time. The online Markdown editor [HackMD](https://hackmd.io/) is a solid platform for practice and production.
+> [GitHub's Mastering Markdown](https://guides.github.com/features/mastering-markdown/) will get you up to speed in no time. The online Markdown editor [HackMD](https://hackmd.io/) is a solid platform for practice and production.
 
 #### GitHub
 
@@ -46,7 +46,7 @@ Markdown is a very simple markup language for formatting text, i.e., adding head
 
 #### Templates
 
-- Technical MIPs must conform to the [Technical MIP Template](https://github.com/makerdao/mips/blob/master/MIP0/Technical-MIP-Template.md). 
+- Technical MIPs must conform to the [Technical MIP Template](https://github.com/makerdao/mips/blob/master/MIP0/Technical-MIP-Template.md).
 - General MIPs must conform to the [General MIP Template](https://github.com/makerdao/mips/blob/master/MIP0/General-MIP-Template.md).
 - Subproposals, on the other hand, must each conform to a specific template referenced in the MIP that defines the process they instantiate.
 
@@ -56,13 +56,19 @@ Once you've picked the appropriate template for your proposal and have a workabl
 - Post the draft [on the appropriate forum section](https://forum.makerdao.com/c/mips/14)
 - Submit it to the [GitHub MIP repository](https://github.com/makerdao/mips)
 
-After the two above tasks have been completed, MIP Editors will help assign a number for the proposal. The proposed MIP (or subproposal - they are treated the same way in terms of how to propose them) will then enter a period of community feedback (most frequently referred to as Request For Comments or RFC). This is a great opportunity to be proactive and interact with the broader community, take suggestions, and improve your proposal. Once the feedback period is over and you've incorporated your final changes, there will be a one-week period before you can formally submit the proposal for voting. Lastly, your proposal will go through a voting period. 
+After the two above tasks have been completed, MIP Editors will help assign a number for the proposal. The proposed MIP (or subproposal - they are treated the same way in terms of how to propose them) will then enter a period of community feedback (most frequently referred to as Request For Comments or RFC). This is a great opportunity to be proactive and interact with the broader community, take suggestions, and improve your proposal. Once the feedback period is over and you've incorporated your final changes, there will be a one-week period before you can formally submit the proposal for voting. Lastly, your proposal will go through a voting period.
 
-If all goes well, by the end of the process you will have contributed a piece of MakerDAO legislation. And that's the gist of it! 
+If all goes well, by the end of the process you will have contributed a piece of MakerDAO legislation. And that's the gist of it!
 
 For a more detailed breakdown of the procedure, please read [MIP0c3](https://mips.makerdao.com/mips/details/MIP0#mip0c3-the-mip-lifecycle).
 
-## Contact Information 
+## IPFS Deployment
+
+This repo contains a workflow that automatically deploys all MIPs to IPFS whenever a commit is pushed to the `master` branch. For this, we're using Filebase and Cloudflare, as you can see by going through said [workflow](https://github.com/makerdao/mips/blob/master/.github/workflows/main.yml).
+
+This deployment can be accessed from [https://mips-ipfs.makerdao.com/](https://mips-ipfs.makerdao.com/).
+
+## Contact Information
 
 ### MIP Editors
 
@@ -72,7 +78,7 @@ Remember that MIP Editors are there to clarify the process and help you. Don't h
 |-|-|-|-|
 | **Pablo** | blimpa#5322 | [@blimpa](https://github.com/blimpa) | [@blimpa](https://forum.makerdao.com/u/blimpa/summary) |
 
-## Helpful Resources 
+## Helpful Resources
 
 * [MIPs Discussion Channel](https://go.rocket.chat/invite?host=chat.makerdao.com&path=invite%2FNPEuhW)
 * [MakerDAO MIPs Forum](https://forum.makerdao.com/c/mips/14)


### PR DESCRIPTION
The current workflow has been failing since it was pushed to the master branch. In order for the MIPs to always be available to the public, I think it's convenient to actually have them deployed to IPFS.

This code has already been tested and it works. The Cloudflare account being used is the one that belongs to MakerDAO, and the Filebase account belongs to TechOps, but this can always be quickly changed by simply updating the `FILEBASE_*` secrets.