### PR TITLE
update MIP104 per latest rates

### DIFF
--- a/MIP104/MIP104.md
+++ b/MIP104/MIP104.md
@@ -285,7 +285,7 @@ Spark DAI Effective Borrow APY: `Dai Savings Rate (EDSR while active) + Spark LR
 Spark Spread:
 
 - LR Spread is 0.50%
-- Asset Spread is 0.60%
+- Asset Spread is 0.96%
 
 ¤¤¤
 
@@ -667,7 +667,7 @@ Maximum `hop` must be set to equal the approximate Effective Rate of MKR Accumul
 ¤¤¤
 
 The `hop` parameter is:
-15,768
+26,280
 
 ¤¤¤
 
@@ -695,7 +695,7 @@ The `want` parameter is:
 ¤¤¤
 
 The `bump` parameter is:
-30,000
+50,000
 
 ¤¤¤
 
@@ -938,13 +938,13 @@ WSTETH-A Spread:
 
 - LR Spread is 0.25%
 - Exposure Spread is 1.49%
-- Asset Spread is 0.32%
+- Asset Spread is 0.42%
 
 WSTETH-B Spread:
 
 - LR Spread is 0.00%
 - Exposure Spread is 1.49%
-- Asset Spread is 0.32%
+- Asset Spread is 0.42%
 
 WBTC-A Spread:
 

--- a/MIP104/MIP104.md
+++ b/MIP104/MIP104.md
@@ -226,7 +226,7 @@ The Base Rate is regularly updated by the Stability Facilitator to approximate (
 
 The Base Rate is:
 
-- **4.18%**
+- **4.05%**
 
 ¤¤¤
 
@@ -240,7 +240,7 @@ The Dai Savings Rate is regularly updated to be equal to (Base rate - 0.25%). Th
 
 The Dai Savings Rate is:
 
-- **3.93%**
+- **3.80%**
 
 ¤¤¤
 
@@ -253,7 +253,7 @@ The Stability Facilitators can take actions related to the EDSR through forum po
 Other parameters and mechanisms that are dependent on the DSR, such as crypto-collateralized stability fees, are affected by the EDSR. This applies to all crypto-collateralized Vault Types except for Spark Protocol.
 
 Spark Protocol has a borrow rate spread that follows the Exposure Model methodology (14.3.1.3) and is defined as: 
-Spark DAI Effective borrow APY = Dai Savings Rate (EDSR while active) + Liquidation Ratio Spread + Asset Spread.
+Spark DAI Effective Borrow APY = Dai Savings Rate (EDSR while active) + Liquidation Ratio Spread + Asset Spread.
 
 #### 3.2.2A
 
@@ -262,7 +262,7 @@ Spark DAI Effective borrow APY = Dai Savings Rate (EDSR while active) + Liquidat
 Spark:
 
 - `SR` = 0.00%
-- `K` = 10.00%
+- `K` = 15.53%
 - `Ka` = 0.00%
 - `Kb` = 30.00%
 - `KFa` = 0.0015%
@@ -771,7 +771,7 @@ The Stability Collateral Yield Benchmark is contained in *14.1.1.1A* and is appr
 
 The Stability Collateral Benchmark Yield is:
 
-- **1.15%**
+- **0.87%**
 
 ¤¤¤
 
@@ -785,7 +785,7 @@ The Yield Collateral Yield Benchmark is contained in *14.1.2.1A* and is approxim
 
 The Yield Collateral Benchmark Yield is:
 
-- **5.54%**
+- **5.45%**
 
 ¤¤¤
 
@@ -836,36 +836,40 @@ Exposure Spread (ES) represents the total exposure as percentage of total DAI mi
 With Parameters:
 
 - `SR` equal to a starting rate
-- `K` equal to the %Exposure (rounded to two decimal places)
+- `K` equal to the Current %Exposure (rounded to two decimal places)
 - `Ka` equal to the First Kink
 - `Kb` equal to the Second Kink
 - `KFa` equal to the Linear increase after the First Kink
 - `KFb` equal to the Linear increase after the Second Kink
-- When 0% ≤ `K` < `Ka`, both `H(K - Ka)` and `H(K - Kb)` are 0, so the equation reduces to `ER = SR`.
-- When `Ka` ≤ `K` < `Kb`, `H(K - Ka)` is 1 and `H(K - Kb)` is 0, so the equation becomes `ER = SR + (K - Ka) * KFa`.
-- When `Kb` ≤ `K` ≤ 100%, both `H(K - Ka)` and `H(K - Kb)` are 1, so the equation becomes `ER = SR + (Kb - Ka) × KFa + (K - Kb) x KFb`.
-- Asset spread (`AS`) represents individual asset exposure as percentage of total DAI minted and is currently used for Liquid Staking Tokens (WSTETH-A, WSTETH-B) and to calculate the Spark DAI borrow
-- Effective APY. It is a piecewise function calculated as:
-    - `AS = SR+(K-Ka)*KFa*H(K-Ka)*[1-H(K-Kb)] + [(Kb-Ka)*KFa+(K-Kb)*KFb]*H(K-Kb)`
-    - With Parameters:
-        - `SR` equal to a starting rate
-        - `K` equal to the %Exposure (rounded to two decimal places)
-        - `Ka` equal to the First Kink
-        - `Kb` equal to the Second Kink
-        - `KFa` equal to the Linear increase after the First Kink
-        - `KFb` equal to the Linear increase after the Second Kink
-        - When 0% ≤ `K` < `Ka`, both `H(K - Ka)` and `H(K - Kb)` are 0, so the equation reduces to `ER = SR`.
-        - When `Ka` ≤ `K` < `Kb`, `H(K - Ka)` is 1 and `H(K - Kb)` is 0, so the equation becomes `ER = SR + (K - Ka) * KFa`.
-        - When `Kb` ≤ `K` ≤ 100%, both `H(K - Ka)` and `H(K - Kb)` are 1, so the equation becomes `ER = SR + (Kb - Ka) * KFa + (K − Kb) * KFb`.
 
-##### 14.3.1.3A
+1. When 0% ≤ `K` < `Ka`, both `H(K - Ka)` and `H(K - Kb)` are 0, so the equation reduces to `ES= SR`.
+2. When `Ka` ≤ `K` < `Kb`, `H(K - Ka)` is 1 and `H(K - Kb)` is 0, so the equation becomes `ES = SR + (K - Ka) * KFa`.
+3. When `Kb` ≤ `K` ≤ 100%, both `H(K - Ka)` and `H(K - Kb)` are 1, so the equation becomes `ES = SR + (Kb - Ka) × KFa + (K - Kb) x KFb`.
+
+Asset spread (`AS`) represents individual asset exposure as percentage of total DAI minted and is currently used for Liquid Staking Tokens (WSTETH-A, WSTETH-B) and to calculate the Spark DAI Borrow Effective APY. It is a piecewise function calculated as:
+
+`AS = SR+(K-Ka)*KFa*H(K-Ka)*[1-H(K-Kb)] + [(Kb-Ka)*KFa+(K-Kb)*KFb]*H(K-Kb)`
+
+With Parameters:
+- `SR` equal to a starting rate
+- `K` equal to the Current %Exposure (rounded to two decimal places)
+- `Ka` equal to the First Kink
+- `Kb` equal to the Second Kink
+- `KFa` equal to the Linear increase after the First Kink
+- `KFb` equal to the Linear increase after the Second Kink
+
+1. When 0% ≤ `K` < `Ka`, both `H(K - Ka)` and `H(K - Kb)` are 0, so the equation reduces to `AS = SR`.
+2. When `Ka` ≤ `K` < `Kb`, `H(K - Ka)` is 1 and `H(K - Kb)` is 0, so the equation becomes `AS = SR + (K - Ka) * KFa`.
+3. When `Kb` ≤ `K` ≤ 100%, both `H(K - Ka)` and `H(K - Kb)` are 1, so the equation becomes `AS = SR + (Kb - Ka) * KFa + (K − Kb) * KFb`.
+
+###### 14.3.1.3.1A
 
 ¤¤¤
 
 ETH:  
 
 - `SR` = 0.00%
-- `K` = 24.92%
+- `K` = 27.43%
 - `Ka` = 0.00%
 - `Kb` = 40.00%
 - `KFa` = 0.01375%
@@ -874,7 +878,7 @@ ETH:
 WSTETH:
 
 - `SR` = 0.00%
-- `K` = 12.12%
+- `K` = 12.46%
 - `Ka` = 0.00%
 - `Kb` = 20.00%
 - `KFa` = 0.00875%
@@ -883,7 +887,7 @@ WSTETH:
 WBTC:
 
 - `SR` = 1.00%
-- `K` = 1.95%
+- `K` = 2.65%
 - `Ka` = 3.00%
 - `Kb` = 10.00%
 - `KFa` = 0.00875%
@@ -891,7 +895,7 @@ WBTC:
 
 ¤¤¤
 
-##### 14.3.1.3B
+###### 14.3.1.3.2A
 
 ¤¤¤
 
@@ -908,7 +912,7 @@ List of Stability Fee Formulas according to the current conditions and chosen me
 
 ¤¤¤
 
-##### 14.3.1.3C
+###### 14.3.1.3.3A
 
 ¤¤¤
 
@@ -1039,7 +1043,7 @@ The Debt Floor parameter controls the minimum amount of DAI that can be minted u
 
 Current ETH-A parameters are:
 
-- Stability Fee: 5.25%
+- Stability Fee: 6.74%
 - Liquidation Ratio: 145%
 - DC-IAM `line`: 15,000,000,000
 - DC-IAM `gap`: 150,000,000
@@ -1063,7 +1067,7 @@ Current ETH-A parameters are:
 
 Current ETH-B parameters are:
 
-- Stability Fee: 5.75%
+- Stability Fee: 7.24%
 - Liquidation Ratio: 130%
 - DC-IAM `line`: 250,000,000
 - DC-IAM `gap`: 20,000,000
@@ -1087,7 +1091,7 @@ Current ETH-B parameters are:
 
 Current ETH-C parameters are:
 
-- Stability Fee: 5.00%
+- Stability Fee: 6.49%
 - Liquidation Ratio: 170%
 - DC-IAM `line`: 2,000,000,000
 - DC-IAM `gap`: 100,000,000
@@ -1111,7 +1115,7 @@ Current ETH-C parameters are:
 
 Current WSTETH-A parameters are:
 
-- Stability Fee: 5.25%
+- Stability Fee: 7.16%
 - Liquidation Ratio: 150%
 - DC-IAM `line`: 750,000,000
 - DC-IAM `gap`: 30,000,000
@@ -1135,7 +1139,7 @@ Current WSTETH-A parameters are:
 
 Current WSTETH-B parameters are:
 
-- Stability Fee: 5.00%
+- Stability Fee: 6.91%
 - Liquidation Ratio: 175%
 - DC-IAM `line`: 1,000,000,000
 - DC-IAM `gap`: 45,000,000
@@ -1159,7 +1163,7 @@ Current WSTETH-B parameters are:
 
 Current WBTC-A parameters are:
 
-- Stability Fee: 5.79%
+- Stability Fee: 6.70%
 - Liquidation Ratio: 145%
 - DC-IAM `line`: 500,000,000
 - DC-IAM `gap`: 2,000,000
@@ -1183,7 +1187,7 @@ Current WBTC-A parameters are:
 
 Current WBTC-B parameters are:
 
-- Stability Fee: 6.29%
+- Stability Fee: 7.20%
 - Liquidation Ratio: 130%
 - DC-IAM `line`: 250,000,000
 - DC-IAM `gap`: 2,000,000
@@ -1207,7 +1211,7 @@ Current WBTC-B parameters are:
 
 Current WBTC-C parameters are:
 
-- Stability Fee: 5.54%
+- Stability Fee: 6.45%
 - Liquidation Ratio: 175%
 - DC-IAM `line`: 500,000,000
 - DC-IAM `gap`: 2,000,000


### PR DESCRIPTION
Aligns MIP104 with recent rate update https://forum.makerdao.com/t/stability-scope-parameter-changes-8/23445

Also added some minor improves to the format.

Also applies minor correction requested by BA Labs that renames ER to AS or ES for the formulas.