### PR TITLE
Fix accidental omission in the Atlas

### DIFF
--- a/MIP101/MIP101.md
+++ b/MIP101/MIP101.md
@@ -273,7 +273,13 @@ FacilitatorDAOs and AllocatorDAOs are Major SubDAOs because they are incubated d
 
 ## 1: The Atlas
 
-Will be populated with the Atlas Preamble in a future edit.
+This MIP specifies the legacy Atlas. The legacy Atlas will soon be upgraded to Atlas v2, which is a version of the Atlas that no longer relies on the legacy MIP system, and consists of a single file that contain all Atlas Documents as a nested tree.
+
+Before the upgrade to Atlas v2, there may be inconsistencies in the Atlas, and between Atlas and the Scopes. In case of conflicts between the Atlas and the Scopes, the Scopes takes precedence as they are generally more up to date.
+
+Facilitators must be careful in using their judgement and common sense to ensure that all interpretations and use of their powers is in accordance with the goals of Endgame Launch: To ensure maximum growth and smooth operations and minimize governance red tape while the first Endgame Products are released, while ensuring actual, pragmatic security of the system is not jeopardized.
+
+Document identifiers do not have to be in order or be sequential.
 
 ## 2: The Governance Scope - GOV
 


### PR DESCRIPTION
Ratified amendment subproposal [MIP102c2-SP34](https://forum.makerdao.com/t/mip102c2-sp34-mip-amendment-subproposal/23971) amended several Scopes and the Atlas. It is a general edit amendment, i.e., it cannot modify Article 1s in Scopes; however, there is no such restriction for the Atlas itself. When we merged the associated PR, we accidentally omitted the Article 1 amendment for the Atlas.

We're hereby fixing  this mistake.